### PR TITLE
[fix][admin] set local policies overwrites "number of bundles" passed during namespace creation

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.apache.pulsar.common.policies.data.PoliciesUtil.getBundles;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -38,9 +39,12 @@ import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
+import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.DispatchRate;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.PolicyName;
 import org.apache.pulsar.common.policies.data.PolicyOperation;
 import org.apache.pulsar.common.policies.data.PublishRate;
@@ -235,5 +239,150 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Response.Status.PRECONDITION_FAILED.getStatusCode());
         }
+    }
+
+    @Test
+    public void testSetBookieAffinityGroupWithEmptyPolicies() throws Exception {
+        // 1. create namespace with empty policies
+        String setBookieAffinityGroupNs = "test-set-bookie-affinity-group-ns";
+        asyncRequests(response -> namespaces.createNamespace(response, testTenant, setBookieAffinityGroupNs, null));
+
+        // 2.set bookie affinity group
+        String primaryAffinityGroup = "primary-affinity-group";
+        String secondaryAffinityGroup = "secondary-affinity-group";
+        BookieAffinityGroupData bookieAffinityGroupDataReq =
+                BookieAffinityGroupData.builder().bookkeeperAffinityGroupPrimary(primaryAffinityGroup)
+                        .bookkeeperAffinityGroupSecondary(secondaryAffinityGroup).build();
+        namespaces.setBookieAffinityGroup(testTenant, setBookieAffinityGroupNs, bookieAffinityGroupDataReq);
+
+        // 3.query namespace num bundles, should be conf.getDefaultNumberOfNamespaceBundles()
+        BundlesData bundlesData = (BundlesData) asyncRequests(
+                response -> namespaces.getBundlesData(response, testTenant, setBookieAffinityGroupNs));
+        assertEquals(bundlesData.getNumBundles(), conf.getDefaultNumberOfNamespaceBundles());
+
+        // 4.assert namespace bookie affinity group
+        BookieAffinityGroupData bookieAffinityGroupDataResp =
+                namespaces.getBookieAffinityGroup(testTenant, setBookieAffinityGroupNs);
+        assertEquals(bookieAffinityGroupDataResp, bookieAffinityGroupDataReq);
+    }
+
+    @Test
+    public void testSetBookieAffinityGroupWithExistBundlePolicies() throws Exception {
+        // 1. create namespace with specified num bundles
+        String setBookieAffinityGroupNs = "test-set-bookie-affinity-group-ns";
+        Policies policies = new Policies();
+        policies.bundles = getBundles(10);
+        asyncRequests(response -> namespaces.createNamespace(response, testTenant, setBookieAffinityGroupNs, policies));
+
+        // 2.set bookie affinity group
+        String primaryAffinityGroup = "primary-affinity-group";
+        String secondaryAffinityGroup = "secondary-affinity-group";
+        BookieAffinityGroupData bookieAffinityGroupDataReq =
+                BookieAffinityGroupData.builder().bookkeeperAffinityGroupPrimary(primaryAffinityGroup)
+                        .bookkeeperAffinityGroupSecondary(secondaryAffinityGroup).build();
+        namespaces.setBookieAffinityGroup(testTenant, setBookieAffinityGroupNs, bookieAffinityGroupDataReq);
+
+        // 3.query namespace num bundles, should be policies.bundles, which we set before
+        BundlesData bundlesData = (BundlesData) asyncRequests(
+                response -> namespaces.getBundlesData(response, testTenant, setBookieAffinityGroupNs));
+        assertEquals(bundlesData, policies.bundles);
+
+        // 4.assert namespace bookie affinity group
+        BookieAffinityGroupData bookieAffinityGroupDataResp =
+                namespaces.getBookieAffinityGroup(testTenant, setBookieAffinityGroupNs);
+        assertEquals(bookieAffinityGroupDataResp, bookieAffinityGroupDataReq);
+    }
+
+    @Test
+    public void testSetNamespaceAntiAffinityGroupWithEmptyPolicies() throws Exception {
+        // 1. create namespace with empty policies
+        String setNamespaceAntiAffinityGroupNs = "test-set--namespace-anti-affinity-group-ns";
+        asyncRequests(
+                response -> namespaces.createNamespace(response, testTenant, setNamespaceAntiAffinityGroupNs, null));
+
+        // 2.set namespace anti affinity group
+        String namespaceAntiAffinityGroupReq = "namespace-anti-affinity-group";
+        namespaces.setNamespaceAntiAffinityGroup(testTenant, setNamespaceAntiAffinityGroupNs,
+                namespaceAntiAffinityGroupReq);
+
+        // 3.query namespace num bundles, should be conf.getDefaultNumberOfNamespaceBundles()
+        BundlesData bundlesData = (BundlesData) asyncRequests(
+                response -> namespaces.getBundlesData(response, testTenant, setNamespaceAntiAffinityGroupNs));
+        assertEquals(bundlesData.getNumBundles(), conf.getDefaultNumberOfNamespaceBundles());
+
+        // 4.assert namespace anti affinity group
+        String namespaceAntiAffinityGroupResp =
+                namespaces.getNamespaceAntiAffinityGroup(testTenant, setNamespaceAntiAffinityGroupNs);
+        assertEquals(namespaceAntiAffinityGroupResp, namespaceAntiAffinityGroupReq);
+    }
+
+    @Test
+    public void testSetNamespaceAntiAffinityGroupWithExistBundlePolicies() throws Exception {
+        // 1. create namespace with specified num bundles
+        String setNamespaceAntiAffinityGroupNs = "test-set--namespace-anti-affinity-group-ns";
+        Policies policies = new Policies();
+        policies.bundles = getBundles(10);
+        asyncRequests(response -> namespaces.createNamespace(response, testTenant, setNamespaceAntiAffinityGroupNs,
+                policies));
+
+        // 2.set namespace anti affinity group
+        String namespaceAntiAffinityGroupReq = "namespace-anti-affinity-group";
+        namespaces.setNamespaceAntiAffinityGroup(testTenant, setNamespaceAntiAffinityGroupNs,
+                namespaceAntiAffinityGroupReq);
+
+        // 3.query namespace num bundles, should be policies.bundles, which we set before
+        BundlesData bundlesData = (BundlesData) asyncRequests(
+                response -> namespaces.getBundlesData(response, testTenant, setNamespaceAntiAffinityGroupNs));
+        assertEquals(bundlesData, policies.bundles);
+
+        // 4.assert namespace anti affinity group
+        String namespaceAntiAffinityGroupResp =
+                namespaces.getNamespaceAntiAffinityGroup(testTenant, setNamespaceAntiAffinityGroupNs);
+        assertEquals(namespaceAntiAffinityGroupResp, namespaceAntiAffinityGroupReq);
+    }
+
+    @Test
+    public void testEnableMigrationWithEmptyPolicies() throws Exception {
+        // 1. create namespace with empty policies
+        String enableMigrationGroupNs = "test-set--namespace-enable-migration-ns";
+        asyncRequests(response -> namespaces.createNamespace(response, testTenant, enableMigrationGroupNs, null));
+
+        // 2.set enable migration
+        boolean enableMigrationReq = true;
+        namespaces.enableMigration(testTenant, enableMigrationGroupNs, enableMigrationReq);
+
+        // 3.query namespace num bundles, should be conf.getDefaultNumberOfNamespaceBundles()
+        BundlesData bundlesData = (BundlesData) asyncRequests(
+                response -> namespaces.getBundlesData(response, testTenant, enableMigrationGroupNs));
+        assertEquals(bundlesData.getNumBundles(), conf.getDefaultNumberOfNamespaceBundles());
+
+        // 4.assert namespace enable migration
+        Policies policiesResp = (Policies) asyncRequests(
+                response -> namespaces.getPolicies(response, testTenant, enableMigrationGroupNs));
+        assertEquals(policiesResp.migrated, enableMigrationReq);
+    }
+
+    @Test
+    public void testEnableMigrationWithExistBundlePolicies() throws Exception {
+        // 1. create namespace with specified num bundles
+        String enableMigrationGroupNs = "test-set--namespace-enable-migration-ns";
+        Policies policiesReq = new Policies();
+        policiesReq.bundles = getBundles(10);
+        asyncRequests(
+                response -> namespaces.createNamespace(response, testTenant, enableMigrationGroupNs, policiesReq));
+
+        // 2.set enable migration
+        boolean enableMigrationReq = true;
+        namespaces.enableMigration(testTenant, enableMigrationGroupNs, enableMigrationReq);
+
+        // 3.query namespace num bundles, should be policies.bundles, which we set before
+        BundlesData bundlesData = (BundlesData) asyncRequests(
+                response -> namespaces.getBundlesData(response, testTenant, enableMigrationGroupNs));
+        assertEquals(bundlesData, policiesReq.bundles);
+
+        // 4.assert namespace enable migration
+        Policies policiesResp = (Policies) asyncRequests(
+                response -> namespaces.getPolicies(response, testTenant, enableMigrationGroupNs));
+        assertEquals(policiesResp.migrated, enableMigrationReq);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
@@ -296,7 +296,7 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
     @Test
     public void testSetNamespaceAntiAffinityGroupWithEmptyPolicies() throws Exception {
         // 1. create namespace with empty policies
-        String setNamespaceAntiAffinityGroupNs = "test-set--namespace-anti-affinity-group-ns";
+        String setNamespaceAntiAffinityGroupNs = "test-set-namespace-anti-affinity-group-ns";
         asyncRequests(
                 response -> namespaces.createNamespace(response, testTenant, setNamespaceAntiAffinityGroupNs, null));
 
@@ -319,7 +319,7 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
     @Test
     public void testSetNamespaceAntiAffinityGroupWithExistBundlePolicies() throws Exception {
         // 1. create namespace with specified num bundles
-        String setNamespaceAntiAffinityGroupNs = "test-set--namespace-anti-affinity-group-ns";
+        String setNamespaceAntiAffinityGroupNs = "test-set-namespace-anti-affinity-group-ns";
         Policies policies = new Policies();
         policies.bundles = getBundles(10);
         asyncRequests(response -> namespaces.createNamespace(response, testTenant, setNamespaceAntiAffinityGroupNs,
@@ -344,7 +344,7 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
     @Test
     public void testEnableMigrationWithEmptyPolicies() throws Exception {
         // 1. create namespace with empty policies
-        String enableMigrationGroupNs = "test-set--namespace-enable-migration-ns";
+        String enableMigrationGroupNs = "test-set-namespace-enable-migration-ns";
         asyncRequests(response -> namespaces.createNamespace(response, testTenant, enableMigrationGroupNs, null));
 
         // 2.set enable migration
@@ -365,7 +365,7 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
     @Test
     public void testEnableMigrationWithExistBundlePolicies() throws Exception {
         // 1. create namespace with specified num bundles
-        String enableMigrationGroupNs = "test-set--namespace-enable-migration-ns";
+        String enableMigrationGroupNs = "test-set-namespace-enable-migration-ns";
         Policies policiesReq = new Policies();
         policiesReq.bundles = getBundles(10);
         asyncRequests(

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -312,8 +312,10 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
 
         assertEquals(activeBrokers.size(), NUM_BROKERS);
 
+        Set<String> antiAffinityEnabledNameSpacesReq = new HashSet<>();
         for (int i = 0; i < activeBrokers.size(); i++) {
             String namespace = antiAffinityEnabledNameSpace + "-" + i;
+            antiAffinityEnabledNameSpacesReq.add(namespace);
             admin.namespaces().createNamespace(namespace, 10);
             admin.namespaces().setNamespaceAntiAffinityGroup(namespace, namespaceAntiAffinityGroup);
             admin.clusters().createFailureDomain(clusterName, namespaceAntiAffinityGroup, FailureDomain.builder()
@@ -324,6 +326,10 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
                     admin.clusters().getFailureDomain(clusterName, namespaceAntiAffinityGroup);
             assertEquals(failureDomainResp.getBrokers(), Set.of(activeBrokers.get(i)));
         }
+
+        List<String> antiAffinityNamespacesResp =
+                admin.namespaces().getAntiAffinityNamespaces(DEFAULT_TENANT, clusterName, namespaceAntiAffinityGroup);
+        assertEquals(new HashSet<>(antiAffinityNamespacesResp), antiAffinityEnabledNameSpacesReq);
 
         Set<String> result = new HashSet<>();
         for (int i = 0; i < activeBrokers.size(); i++) {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -318,6 +318,11 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
             admin.namespaces().setNamespaceAntiAffinityGroup(namespace, namespaceAntiAffinityGroup);
             admin.clusters().createFailureDomain(clusterName, namespaceAntiAffinityGroup, FailureDomain.builder()
                     .brokers(Set.of(activeBrokers.get(i))).build());
+            String namespaceAntiAffinityGroupResp = admin.namespaces().getNamespaceAntiAffinityGroup(namespace);
+            assertEquals(namespaceAntiAffinityGroupResp, namespaceAntiAffinityGroup);
+            FailureDomain failureDomainResp =
+                    admin.clusters().getFailureDomain(clusterName, namespaceAntiAffinityGroup);
+            assertEquals(failureDomainResp.getBrokers(), Set.of(activeBrokers.get(i)));
         }
 
         Set<String> result = new HashSet<>();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -303,7 +303,7 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
     }
 
     @Test(timeOut = 80 * 1000)
-    public void testAntiaffinityPolicy() throws PulsarAdminException {
+    public void testAntiAffinityPolicy() throws PulsarAdminException {
         final String namespaceAntiAffinityGroup = "my-anti-affinity-filter";
         final String antiAffinityEnabledNameSpace = DEFAULT_TENANT + "/my-ns-filter" + nsSuffix;
         final int numPartition = 20;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -316,7 +316,7 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
         for (int i = 0; i < activeBrokers.size(); i++) {
             String namespace = antiAffinityEnabledNameSpace + "-" + i;
             antiAffinityEnabledNameSpacesReq.add(namespace);
-            admin.namespaces().createNamespace(namespace, 10);
+            admin.namespaces().createNamespace(namespace, 1);
             admin.namespaces().setNamespaceAntiAffinityGroup(namespace, namespaceAntiAffinityGroup);
             admin.clusters().createFailureDomain(clusterName, namespaceAntiAffinityGroup, FailureDomain.builder()
                     .brokers(Set.of(activeBrokers.get(i))).build());


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar/issues/23897

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Set local policies will overwrite "number of bundles" passed during namespace creation. If we don't call any get namespace policies operation, local policies will not be created, so it will be overwritten.
https://github.com/apache/pulsar/blob/8879b3ba9daa6de9b8b78bbce89bab68cc37cf0b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java#L164-L182

The following steps can reproduce the problem.
1. pulsar-admin namespaces create t/n --bundles 10
2. pulsar-admin namespaces set-bookie-affinity-group --primary-group temp t/n
3. pulsar-admin namespaces bundles t/n

But the following steps will not reproduce the problem.
1. pulsar-admin namespaces create t/n --bundles 10
2. pulsar-admin namespaces bundles t/n
3. pulsar-admin namespaces set-bookie-affinity-group --primary-group temp t/n
4. pulsar-admin namespaces bundles t/n

### Modifications

<!-- Describe the modifications you've done. -->

If  local policies is not present, first try to use namespace policies bundle data, then fallback to `config().getDefaultNumberOfNamespaceBundles()`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->