### PR TITLE
[improve][client] Add independent multiTopicsSinglePartitionReceiverQueueSize config for single partition consumer in multi-topics consumer to reduce memory consumption

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -454,7 +454,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * multi-topics consumer.
      *
      * <p>For partitioned-topic, each partition consumer's receiverQueueSize is the min value of receiverQueueSize and
-     * (maxTotalReceiverQueueSizeAcrossPartitions() / numPartitions)
+     * (maxTotalReceiverQueueSizeAcrossPartitions / numPartitions)
      *
      * @param multiTopicsSinglePartitionReceiverQueueSize
      *            the receiverQueueSize of single partition consumer in multi-topics consumer

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -423,6 +423,46 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> receiverQueueSize(int receiverQueueSize);
 
     /**
+     * Sets whether to enable {@link #multiTopicsSinglePartitionReceiverQueueSize(int)} config or not.
+     *
+     * <p>By default, this config is false, then every partition consumer's receiverQueueSize is equal to
+     * multi-topics consumer's receiverQueueSize.
+     *
+     * <p>If set to true, then every partition consumer's receiverQueueSize in multi-topics consumer is set to
+     * {@link #multiTopicsSinglePartitionReceiverQueueSize(int)}
+     *
+     * <p>Attention: Partitioned-topic's receiverQueueSize calculate logic is a little bit different from
+     * non-partitioned topic, see {@link #maxTotalReceiverQueueSizeAcrossPartitions(int)}
+     *
+     * @param multiTopicsSinglePartitionReceiverQueueSizeEnable
+     *            enable multiTopicsSinglePartitionReceiverQueueSize or not
+     * @return the consumer builder instance
+     */
+    ConsumerBuilder<T> enableMultiTopicsSinglePartitionReceiverQueueSize(
+            boolean multiTopicsSinglePartitionReceiverQueueSizeEnable);
+
+    /**
+     * Sets single partition consumer's receiverQueueSize in multi-topics consumer.
+     *
+     * <p>Attention: This config only takes effect when
+     * {@link #enableMultiTopicsSinglePartitionReceiverQueueSize(boolean)} is set to true.
+     *
+     * <p>For partitioned-topic with n partitions, Pulsar creates n independent ConsumerImpl instances for each
+     * partition. For non-partitioned topic, Pulsar creates one ConsumerImpl instance.
+     *
+     * <p>This config just set each ConsumerImpl's receiverQueueSize to multiTopicsSingleConsumerReceiverQueueSize in
+     * multi-topics consumer.
+     *
+     * <p>For partitioned-topic, each partition consumer's receiverQueueSize is the min value of receiverQueueSize and
+     * (maxTotalReceiverQueueSizeAcrossPartitions() / numPartitions)
+     *
+     * @param multiTopicsSinglePartitionReceiverQueueSize
+     *            the receiverQueueSize of single partition consumer in multi-topics consumer
+     * @return the consumer builder instance
+     */
+    ConsumerBuilder<T> multiTopicsSinglePartitionReceiverQueueSize(int multiTopicsSinglePartitionReceiverQueueSize);
+
+    /**
      * Sets amount of time for group consumer acknowledgments.
      *
      * <p>By default, the consumer uses a 100 ms grouping time to send out acknowledgments to the broker.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -249,6 +249,29 @@ public interface ReaderBuilder<T> extends Cloneable {
     ReaderBuilder<T> receiverQueueSize(int receiverQueueSize);
 
     /**
+     * Sets whether to enable {@link #multiTopicsSinglePartitionReceiverQueueSize(int)} config or not.
+     *
+     * <p>See also {@link ConsumerBuilder#enableMultiTopicsSinglePartitionReceiverQueueSize(boolean)}
+     *
+     * @param multiTopicsSinglePartitionReceiverQueueSizeEnable
+     *           enable multiTopicsSinglePartitionReceiverQueueSize or not
+     * @return the reader builder instance
+     */
+    ReaderBuilder<T> enableMultiTopicsSinglePartitionReceiverQueueSize(
+            boolean multiTopicsSinglePartitionReceiverQueueSizeEnable);
+
+    /**
+     * Sets single partition consumer's receiverQueueSize in multi-topics consumer.
+     *
+     * <p>See also {@link ConsumerBuilder#multiTopicsSinglePartitionReceiverQueueSize(int)}
+     *
+     * @param multiTopicsSinglePartitionReceiverQueueSize
+     *            the receiverQueueSize of single partition consumer in multi-topics consumer
+     * @return the reader builder instance
+     */
+    ReaderBuilder<T> multiTopicsSinglePartitionReceiverQueueSize(int multiTopicsSinglePartitionReceiverQueueSize);
+
+    /**
      * Specify a reader name.
      *
      * <p>The reader name is purely informational and can used to track a particular reader in the reported stats.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -378,6 +378,22 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
+    public ConsumerBuilder<T> enableMultiTopicsSinglePartitionReceiverQueueSize(
+            boolean multiTopicsSinglePartitionReceiverQueueSizeEnable) {
+        conf.setMultiTopicsSinglePartitionReceiverQueueSizeEnable(multiTopicsSinglePartitionReceiverQueueSizeEnable);
+        return this;
+    }
+
+    @Override
+    public ConsumerBuilder<T> multiTopicsSinglePartitionReceiverQueueSize(
+            int multiTopicsSinglePartitionReceiverQueueSize) {
+        checkArgument(multiTopicsSinglePartitionReceiverQueueSize >= 0,
+                "multiTopicsSinglePartitionReceiverQueueSize needs to be >= 0");
+        conf.setMultiTopicsSinglePartitionReceiverQueueSize(multiTopicsSinglePartitionReceiverQueueSize);
+        return this;
+    }
+
+    @Override
     public ConsumerBuilder<T> acknowledgmentGroupTime(long delay, TimeUnit unit) {
         checkArgument(delay >= 0, "acknowledgmentGroupTime needs to be >= 0");
         conf.setAcknowledgementsGroupTimeMicros(unit.toMicros(delay));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1110,7 +1110,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             }
             allTopicPartitionsNumber.addAndGet(numPartitions);
 
-            int receiverQueueSize = Math.min(getSingleConsumerReceiverQueueSize(),
+            int receiverQueueSize = Math.min(getSinglePartitionReceiverQueueSize(),
                 conf.getMaxTotalReceiverQueueSizeAcrossPartitions() / numPartitions);
             ConsumerConfigurationData<T> configurationData = getInternalConsumerConfig();
             configurationData.setReceiverQueueSize(receiverQueueSize);
@@ -1172,7 +1172,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     } else {
                         internalConfig.setStartPaused(paused);
                         ConsumerConfigurationData<T> configurationData = getInternalConsumerConfig();
-                        configurationData.setReceiverQueueSize(getSingleConsumerReceiverQueueSize());
+                        configurationData.setReceiverQueueSize(getSinglePartitionReceiverQueueSize());
                         ConsumerImpl<T> newConsumer = createInternalConsumer(internalConfig, topicName,
                                 -1, subscribeFuture, createIfDoesNotExist, schema);
                         if (paused) {
@@ -1219,7 +1219,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                                                    int partitionIndex, CompletableFuture<Consumer<T>> subFuture,
                                                    boolean createIfDoesNotExist, Schema<T> schema) {
         BatchReceivePolicy internalBatchReceivePolicy = BatchReceivePolicy.builder()
-                .maxNumMessages(Math.max(getSingleConsumerReceiverQueueSize() / 2, 1))
+                .maxNumMessages(Math.max(getSinglePartitionReceiverQueueSize() / 2, 1))
                 .maxNumBytes(-1)
                 .timeout(1, TimeUnit.MILLISECONDS)
                 .build();
@@ -1639,10 +1639,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         });
     }
 
-    private int getSingleConsumerReceiverQueueSize() {
-        return conf.isMultiTopicsSingleConsumerReceiverQueueSizeEnabled() ?
-                conf.getMultiTopicsSingleConsumerReceiverQueueSize() :
-                conf.getReceiverQueueSize();
+    private int getSinglePartitionReceiverQueueSize() {
+        return conf.isMultiTopicsSinglePartitionReceiverQueueSizeEnable()
+                ? conf.getMultiTopicsSinglePartitionReceiverQueueSize() : conf.getReceiverQueueSize();
     }
 
     private ConsumerInterceptors<T> getInternalConsumerInterceptors(ConsumerInterceptors<T> multiTopicInterceptors) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1450,6 +1450,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                         CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
                         ConsumerConfigurationData<T> configurationData = getInternalConsumerConfig();
                         configurationData.setStartPaused(paused);
+                        // It is kind of difficult to get previous configured receiverQueueSize.
+                        // So we just use getSinglePartitionReceiverQueueSize() to set new partition consumer's
+                        // receiverQueueSize, it is developer's duty to set this to a reasonable value
+                        configurationData.setReceiverQueueSize(getSinglePartitionReceiverQueueSize());
                         ConsumerImpl<T> newConsumer = createInternalConsumer(configurationData, partitionName,
                                 partitionIndex, subFuture, true, schema);
                         synchronized (pauseMutex) {
@@ -1639,7 +1643,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         });
     }
 
-    private int getSinglePartitionReceiverQueueSize() {
+    protected int getSinglePartitionReceiverQueueSize() {
         return conf.isMultiTopicsSinglePartitionReceiverQueueSizeEnable()
                 ? conf.getMultiTopicsSinglePartitionReceiverQueueSize() : conf.getReceiverQueueSize();
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1110,7 +1110,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             }
             allTopicPartitionsNumber.addAndGet(numPartitions);
 
-            int receiverQueueSize = Math.min(conf.getReceiverQueueSize(),
+            int receiverQueueSize = Math.min(conf.getMultiTopicsSingleConsumerReceiverQueueSize(),
                 conf.getMaxTotalReceiverQueueSizeAcrossPartitions() / numPartitions);
             ConsumerConfigurationData<T> configurationData = getInternalConsumerConfig();
             configurationData.setReceiverQueueSize(receiverQueueSize);
@@ -1171,6 +1171,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                         return existingValue;
                     } else {
                         internalConfig.setStartPaused(paused);
+                        ConsumerConfigurationData<T> configurationData = getInternalConsumerConfig();
+                        configurationData.setReceiverQueueSize(conf.getMultiTopicsSingleConsumerReceiverQueueSize());
                         ConsumerImpl<T> newConsumer = createInternalConsumer(internalConfig, topicName,
                                 -1, subscribeFuture, createIfDoesNotExist, schema);
                         if (paused) {
@@ -1217,7 +1219,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                                                    int partitionIndex, CompletableFuture<Consumer<T>> subFuture,
                                                    boolean createIfDoesNotExist, Schema<T> schema) {
         BatchReceivePolicy internalBatchReceivePolicy = BatchReceivePolicy.builder()
-                .maxNumMessages(Math.max(configurationData.getReceiverQueueSize() / 2, 1))
+                .maxNumMessages(Math.max(configurationData.getMultiTopicsSingleConsumerReceiverQueueSize() / 2, 1))
                 .maxNumBytes(-1)
                 .timeout(1, TimeUnit.MILLISECONDS)
                 .build();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1110,7 +1110,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             }
             allTopicPartitionsNumber.addAndGet(numPartitions);
 
-            int receiverQueueSize = Math.min(conf.getMultiTopicsSingleConsumerReceiverQueueSize(),
+            int receiverQueueSize = Math.min(getSingleConsumerReceiverQueueSize(),
                 conf.getMaxTotalReceiverQueueSizeAcrossPartitions() / numPartitions);
             ConsumerConfigurationData<T> configurationData = getInternalConsumerConfig();
             configurationData.setReceiverQueueSize(receiverQueueSize);
@@ -1172,7 +1172,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     } else {
                         internalConfig.setStartPaused(paused);
                         ConsumerConfigurationData<T> configurationData = getInternalConsumerConfig();
-                        configurationData.setReceiverQueueSize(conf.getMultiTopicsSingleConsumerReceiverQueueSize());
+                        configurationData.setReceiverQueueSize(getSingleConsumerReceiverQueueSize());
                         ConsumerImpl<T> newConsumer = createInternalConsumer(internalConfig, topicName,
                                 -1, subscribeFuture, createIfDoesNotExist, schema);
                         if (paused) {
@@ -1219,7 +1219,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                                                    int partitionIndex, CompletableFuture<Consumer<T>> subFuture,
                                                    boolean createIfDoesNotExist, Schema<T> schema) {
         BatchReceivePolicy internalBatchReceivePolicy = BatchReceivePolicy.builder()
-                .maxNumMessages(Math.max(configurationData.getMultiTopicsSingleConsumerReceiverQueueSize() / 2, 1))
+                .maxNumMessages(Math.max(getSingleConsumerReceiverQueueSize() / 2, 1))
                 .maxNumBytes(-1)
                 .timeout(1, TimeUnit.MILLISECONDS)
                 .build();
@@ -1637,6 +1637,12 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             Collections.sort(list);
             return list;
         });
+    }
+
+    private int getSingleConsumerReceiverQueueSize() {
+        return conf.isMultiTopicsSingleConsumerReceiverQueueSizeEnabled() ?
+                conf.getMultiTopicsSingleConsumerReceiverQueueSize() :
+                conf.getReceiverQueueSize();
     }
 
     private ConsumerInterceptors<T> getInternalConsumerInterceptors(ConsumerInterceptors<T> multiTopicInterceptors) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -71,6 +71,8 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
         consumerConfiguration.setSubscriptionType(SubscriptionType.Exclusive);
         consumerConfiguration.setSubscriptionMode(SubscriptionMode.NonDurable);
         consumerConfiguration.setReceiverQueueSize(readerConfiguration.getReceiverQueueSize());
+        consumerConfiguration.setMultiTopicsSingleConsumerReceiverQueueSizeEnabled(
+                readerConfiguration.isMultiTopicsSingleConsumerReceiverQueueSizeEnabled());
         consumerConfiguration.setMultiTopicsSingleConsumerReceiverQueueSize(
                 readerConfiguration.getMultiTopicsSingleConsumerReceiverQueueSize());
         consumerConfiguration.setReadCompacted(readerConfiguration.isReadCompacted());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -71,6 +71,8 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
         consumerConfiguration.setSubscriptionType(SubscriptionType.Exclusive);
         consumerConfiguration.setSubscriptionMode(SubscriptionMode.NonDurable);
         consumerConfiguration.setReceiverQueueSize(readerConfiguration.getReceiverQueueSize());
+        consumerConfiguration.setMultiTopicsSingleConsumerReceiverQueueSize(
+                readerConfiguration.getMultiTopicsSingleConsumerReceiverQueueSize());
         consumerConfiguration.setReadCompacted(readerConfiguration.isReadCompacted());
         consumerConfiguration.setPoolMessages(readerConfiguration.isPoolMessages());
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -71,10 +71,10 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
         consumerConfiguration.setSubscriptionType(SubscriptionType.Exclusive);
         consumerConfiguration.setSubscriptionMode(SubscriptionMode.NonDurable);
         consumerConfiguration.setReceiverQueueSize(readerConfiguration.getReceiverQueueSize());
-        consumerConfiguration.setMultiTopicsSingleConsumerReceiverQueueSizeEnabled(
-                readerConfiguration.isMultiTopicsSingleConsumerReceiverQueueSizeEnabled());
-        consumerConfiguration.setMultiTopicsSingleConsumerReceiverQueueSize(
-                readerConfiguration.getMultiTopicsSingleConsumerReceiverQueueSize());
+        consumerConfiguration.setMultiTopicsSinglePartitionReceiverQueueSizeEnable(
+                readerConfiguration.isMultiTopicsSinglePartitionReceiverQueueSizeEnable());
+        consumerConfiguration.setMultiTopicsSinglePartitionReceiverQueueSize(
+                readerConfiguration.getMultiTopicsSinglePartitionReceiverQueueSize());
         consumerConfiguration.setReadCompacted(readerConfiguration.isReadCompacted());
         consumerConfiguration.setPoolMessages(readerConfiguration.isPoolMessages());
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -207,6 +207,22 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
     }
 
     @Override
+    public ReaderBuilder<T> enableMultiTopicsSinglePartitionReceiverQueueSize(
+            boolean multiTopicsSinglePartitionReceiverQueueSizeEnable) {
+        conf.setMultiTopicsSinglePartitionReceiverQueueSizeEnable(multiTopicsSinglePartitionReceiverQueueSizeEnable);
+        return this;
+    }
+
+    @Override
+    public ReaderBuilder<T> multiTopicsSinglePartitionReceiverQueueSize(
+            int multiTopicsSinglePartitionReceiverQueueSize) {
+        checkArgument(multiTopicsSinglePartitionReceiverQueueSize >= 0,
+                "multiTopicsSinglePartitionReceiverQueueSize needs to be >= 0");
+        conf.setMultiTopicsSinglePartitionReceiverQueueSize(multiTopicsSinglePartitionReceiverQueueSize);
+        return this;
+    }
+
+    @Override
     public ReaderBuilder<T> readerName(String readerName) {
         conf.setReaderName(readerName);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -133,29 +133,28 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private int receiverQueueSize = 1000;
 
     @ApiModelProperty(
-            name = "multiTopicsSingleConsumerReceiverQueueSizeEnabled",
-            value = "Determine whether multiTopicsSingleConsumerReceiverQueueSize is effective.\n"
+            name = "multiTopicsSinglePartitionReceiverQueueSizeEnable",
+            value = "Determine whether multiTopicsSinglePartitionReceiverQueueSize is effective.\n"
                     + "\n"
                     + "For backward compatibility, the default value is set to false."
     )
-    private boolean multiTopicsSingleConsumerReceiverQueueSizeEnabled = false;
+    private boolean multiTopicsSinglePartitionReceiverQueueSizeEnable = false;
 
     @ApiModelProperty(
-            name = "multiTopicsSingleConsumerReceiverQueueSize",
-            value = "Size of a single consumer's receiver queue in multi-topics consumer.\n"
-                    + "\n"
+            name = "multiTopicsSinglePartitionReceiverQueueSize",
+            value = "Size of a single partition consumer's receiver queue in multi-topics consumer.\n" + "\n"
                     + "In MultiTopicsConsumerImpl, if you have a partitioned-topic with 10 partitions, set this value"
-                    + " to 200, then each non-partitioned topic consumer's receiverQueueSize 200, and "
+                    + " to 200, then each partition consumer's receiverQueueSize is 200, and "
                     + "MultiTopicsConsumerImpl's receiverQueueSize is 1000, so the max messages in memory is 1000 + "
                     + "200 * 10 = 3000.\n"
                     + "\n"
-                    + "In PatternMultiTopicsConsumerImpl, if you subscribe to a regex pattern that matches 1000 "
-                    + "non-partitioned topics, set this to 50, then each non-partitioned topic consumer's "
-                    + "receiverQueueSize 200, and PatternMultiTopicsConsumerImpl's receiverQueueSize is 1000, so the "
-                    + "max messages in memory is 1000 + 50 * 200 = 11000.\n"
+                    + "In PatternMultiTopicsConsumerImpl, if you subscribe to a regex pattern that matches 600 topics"
+                    + " with 1000 partitions, set this to 50, then each partition consumer's receiverQueueSize is "
+                    + "200, and PatternMultiTopicsConsumerImpl's receiverQueueSize is 1000, so the max messages in "
+                    + "memory is 1000 + 50 * 200 = 11000.\n"
                     + "\n"
     )
-    private int multiTopicsSingleConsumerReceiverQueueSize = 1000;
+    private int multiTopicsSinglePartitionReceiverQueueSize = 1000;
 
     @ApiModelProperty(
             name = "acknowledgementsGroupTimeMicros",

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -133,6 +133,14 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private int receiverQueueSize = 1000;
 
     @ApiModelProperty(
+            name = "multiTopicsSingleConsumerReceiverQueueSizeEnabled",
+            value = "Determine whether multiTopicsSingleConsumerReceiverQueueSize is effective.\n"
+                    + "\n"
+                    + "For backward compatibility, the default value is set to false."
+    )
+    private boolean multiTopicsSingleConsumerReceiverQueueSizeEnabled = false;
+
+    @ApiModelProperty(
             name = "multiTopicsSingleConsumerReceiverQueueSize",
             value = "Size of a single consumer's receiver queue in multi-topics consumer.\n"
                     + "\n"
@@ -146,7 +154,6 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
                     + "receiverQueueSize 200, and PatternMultiTopicsConsumerImpl's receiverQueueSize is 1000, so the "
                     + "max messages in memory is 1000 + 50 * 200 = 11000.\n"
                     + "\n"
-                    + "For backward compatibility, the default value is set to 1000, the same as receiverQueueSize."
     )
     private int multiTopicsSingleConsumerReceiverQueueSize = 1000;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -133,6 +133,24 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private int receiverQueueSize = 1000;
 
     @ApiModelProperty(
+            name = "multiTopicsSingleConsumerReceiverQueueSize",
+            value = "Size of a single consumer's receiver queue in multi-topics consumer.\n"
+                    + "\n"
+                    + "In MultiTopicsConsumerImpl, if you have a partitioned-topic with 10 partitions, set this value"
+                    + " to 200, then each non-partitioned topic consumer's receiverQueueSize 200, and "
+                    + "MultiTopicsConsumerImpl's receiverQueueSize is 1000, so the max messages in memory is 1000 + "
+                    + "200 * 10 = 3000.\n"
+                    + "\n"
+                    + "In PatternMultiTopicsConsumerImpl, if you subscribe to a regex pattern that matches 1000 "
+                    + "non-partitioned topics, set this to 50, then each non-partitioned topic consumer's "
+                    + "receiverQueueSize 200, and PatternMultiTopicsConsumerImpl's receiverQueueSize is 1000, so the "
+                    + "max messages in memory is 1000 + 50 * 200 = 11000.\n"
+                    + "\n"
+                    + "For backward compatibility, the default value is set to 1000, the same as receiverQueueSize."
+    )
+    private int multiTopicsSingleConsumerReceiverQueueSize = 1000;
+
+    @ApiModelProperty(
             name = "acknowledgementsGroupTimeMicros",
             value = "Group a consumer acknowledgment for a specified time.\n"
                     + "\n"

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -69,6 +69,14 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
     private int receiverQueueSize = 1000;
 
     @ApiModelProperty(
+            name = "multiTopicsSingleConsumerReceiverQueueSizeEnabled",
+            value = "Determine whether multiTopicsSingleConsumerReceiverQueueSize is effective.\n"
+                    + "\n"
+                    + "For backward compatibility, the default value is set to false."
+    )
+    private boolean multiTopicsSingleConsumerReceiverQueueSizeEnabled = false;
+
+    @ApiModelProperty(
             name = "multiTopicsSingleConsumerReceiverQueueSize",
             value = "Size of a single consumer's receiver queue in multi-topics consumer.\n"
                     + "\n"
@@ -82,7 +90,6 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
                     + "receiverQueueSize 200, and PatternMultiTopicsConsumerImpl's receiverQueueSize is 1000, so the "
                     + "max messages in memory is 1000 + 50 * 200 = 11000.\n"
                     + "\n"
-                    + "For backward compatibility, the default value is set to 1000, the same as receiverQueueSize."
     )
     private int multiTopicsSingleConsumerReceiverQueueSize = 1000;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -69,6 +69,24 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
     private int receiverQueueSize = 1000;
 
     @ApiModelProperty(
+            name = "multiTopicsSingleConsumerReceiverQueueSize",
+            value = "Size of a single consumer's receiver queue in multi-topics consumer.\n"
+                    + "\n"
+                    + "In MultiTopicsConsumerImpl, if you have a partitioned-topic with 10 partitions, set this value"
+                    + " to 200, then each non-partitioned topic consumer's receiverQueueSize 200, and "
+                    + "MultiTopicsConsumerImpl's receiverQueueSize is 1000, so the max messages in memory is 1000 + "
+                    + "200 * 10 = 3000.\n"
+                    + "\n"
+                    + "In PatternMultiTopicsConsumerImpl, if you subscribe to a regex pattern that matches 1000 "
+                    + "non-partitioned topics, set this to 50, then each non-partitioned topic consumer's "
+                    + "receiverQueueSize 200, and PatternMultiTopicsConsumerImpl's receiverQueueSize is 1000, so the "
+                    + "max messages in memory is 1000 + 50 * 200 = 11000.\n"
+                    + "\n"
+                    + "For backward compatibility, the default value is set to 1000, the same as receiverQueueSize."
+    )
+    private int multiTopicsSingleConsumerReceiverQueueSize = 1000;
+
+    @ApiModelProperty(
             name = "readerListener",
             value = "A listener that is called for message received."
     )

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -69,29 +69,28 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
     private int receiverQueueSize = 1000;
 
     @ApiModelProperty(
-            name = "multiTopicsSingleConsumerReceiverQueueSizeEnabled",
-            value = "Determine whether multiTopicsSingleConsumerReceiverQueueSize is effective.\n"
+            name = "multiTopicsSinglePartitionReceiverQueueSizeEnable",
+            value = "Determine whether multiTopicsSinglePartitionReceiverQueueSize is effective.\n"
                     + "\n"
                     + "For backward compatibility, the default value is set to false."
     )
-    private boolean multiTopicsSingleConsumerReceiverQueueSizeEnabled = false;
+    private boolean multiTopicsSinglePartitionReceiverQueueSizeEnable = false;
 
     @ApiModelProperty(
-            name = "multiTopicsSingleConsumerReceiverQueueSize",
-            value = "Size of a single consumer's receiver queue in multi-topics consumer.\n"
-                    + "\n"
+            name = "multiTopicsSinglePartitionReceiverQueueSize",
+            value = "Size of a single partition consumer's receiver queue in multi-topics consumer.\n" + "\n"
                     + "In MultiTopicsConsumerImpl, if you have a partitioned-topic with 10 partitions, set this value"
-                    + " to 200, then each non-partitioned topic consumer's receiverQueueSize 200, and "
+                    + " to 200, then each partition consumer's receiverQueueSize is 200, and "
                     + "MultiTopicsConsumerImpl's receiverQueueSize is 1000, so the max messages in memory is 1000 + "
                     + "200 * 10 = 3000.\n"
                     + "\n"
-                    + "In PatternMultiTopicsConsumerImpl, if you subscribe to a regex pattern that matches 1000 "
-                    + "non-partitioned topics, set this to 50, then each non-partitioned topic consumer's "
-                    + "receiverQueueSize 200, and PatternMultiTopicsConsumerImpl's receiverQueueSize is 1000, so the "
-                    + "max messages in memory is 1000 + 50 * 200 = 11000.\n"
+                    + "In PatternMultiTopicsConsumerImpl, if you subscribe to a regex pattern that matches 600 topics"
+                    + " with 1000 partitions, set this to 50, then each partition consumer's receiverQueueSize is "
+                    + "200, and PatternMultiTopicsConsumerImpl's receiverQueueSize is 1000, so the max messages in "
+                    + "memory is 1000 + 50 * 200 = 11000.\n"
                     + "\n"
     )
-    private int multiTopicsSingleConsumerReceiverQueueSize = 1000;
+    private int multiTopicsSinglePartitionReceiverQueueSize = 1000;
 
     @ApiModelProperty(
             name = "readerListener",


### PR DESCRIPTION
### Motivation

There no independent `receiverQueueSize` config for single partition consumer in `MultiTopicsConsumerImpl` and `PatternMultiTopicsConsumerImpl`. Although `maxTotalReceiverQueueSizeAcrossPartitions` config can limit in-memory messages of a single topic with multi-partitions, but it can't limit in-memory messages of multi-topics.

For example, if we subscribe to a regex pattern that matches 1000 non-partitioned topics. Before this PR, each non-partitioned topic consumer's `receiverQueueSize` is 1000(`ConsumerImpl` uses the same `receiverQueueSize` value as `PatternMultiTopicsConsumerImpl`), the max messages in memory is 1000 + 1000 * 1000 = 1001000. Let's ignore the insignificant number 1000, if each message size is 8Kb, then we need 1000000 * 8Kb = 7,812.5MB memory to boot our application in catch-up read situation, which is unnecessary.

https://github.com/apache/pulsar/blob/e6560657e20d30103f2f01c3a24600dad1ba9ab6/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L236-L249

For backward compatibility, add `multiTopicsSinglePartitionReceiverQueueSizeEnable` switch, the default value is set to false.

### Modifications

Add independent `multiTopicsSinglePartitionReceiverQueueSize` config for single consumer in `MultiTopicsConsumerImpl` to reduce memory consumption.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->