### PR TITLE
[fix][broker] Fix replicator producer can not share with other exclusive producers

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.TopicBusyExceptio
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.ProducerBuilderImpl;
@@ -197,6 +198,7 @@ public abstract class AbstractReplicator implements Replicator {
             ProducerBuilderImpl builderImpl = (ProducerBuilderImpl) producerBuilder;
             builderImpl.getConf().setNonPartitionedTopicExpected(true);
             builderImpl.getConf().setReplProducer(true);
+            builderImpl.getConf().setAccessMode(ProducerAccessMode.Shared);
             return producerBuilder.createAsync().thenAccept(producer -> {
                 setProducerAndTriggerReadEntries(producer);
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -1386,6 +1386,6 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     }
 
     private boolean hasAnyNonReplicatorProducer() {
-        return !producers.isEmpty() && !producers.values().stream().allMatch(Producer::isRemote);
+        return !producers.isEmpty() && producers.values().stream().anyMatch(p -> !p.isRemote());
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -63,6 +63,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import lombok.Cleanup;
 import lombok.Data;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -87,6 +88,7 @@ import org.apache.pulsar.client.api.InjectedClientCnxClientBuilder;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
@@ -1858,4 +1860,29 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         // Verify: all inflight tasks are done.
         ensureNoBacklogByInflightTask(getReplicator(topicName));
     }
+
+    @DataProvider(name = "producerAccessMode")
+    public Object[][] producerAccessModeProvider() {
+        return new Object[][]{{ProducerAccessMode.Exclusive}, {ProducerAccessMode.ExclusiveWithFencing},
+                {ProducerAccessMode.WaitForExclusive}};
+    }
+
+    @Test(dataProvider = "producerAccessMode")
+    public void testReplicatorProducerWithExclusiveAccessMode(ProducerAccessMode producerAccessMode) throws Exception {
+        final String topicName =
+                BrokerTestUtil.newUniqueName("persistent://" + replicatedNamespace + "/exclusive-topic");
+        final String subscribeName = "subscribe_1";
+        final byte[] msgValue = "test".getBytes();
+
+        // cluster1 replicates exclusive-topic messages to cluster2, but cluster2 has an exclusive producer.
+        @Cleanup Producer<byte[]> producer1 = client1.newProducer().topic(topicName).create();
+        @Cleanup Producer<byte[]> producer2 =
+                client2.newProducer().topic(topicName).accessMode(producerAccessMode).create();
+        @Cleanup Consumer<byte[]> consumer2 =
+                client2.newConsumer().topic(topicName).subscriptionName(subscribeName).subscribe();
+        producer1.newMessage().value(msgValue).send();
+        pulsar1.getBrokerService().checkReplicationPolicies();
+        assertEquals(consumer2.receive(10, TimeUnit.SECONDS).getValue(), msgValue);
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24914

<!-- or this PR is one task of an issue -->

### Motivation

Fix geo replication doesn't support exclusive access producers.

### Modifications

Modify AbstractTopic#incrementTopicEpochIfNeeded() method to support normal exclusive producers can share with replicator producer.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as (please describe tests).

Old test cases are covered by `ExclusiveProducerTest` test class.

New test method is `OneWayReplicatorTest#testReplicatorProducerWithExclusiveAccessMode()`.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: