### PR TITLE
[fix][broker] Add schema version support in rest produce api

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
@@ -196,7 +196,7 @@ public class TopicsBase extends PersistentTopicsBase {
         try {
             String producerName = (null == request.getProducerName() || request.getProducerName().isEmpty())
                     ? defaultProducerName : request.getProducerName();
-            List<Message> messages = buildMessage(request, schema, producerName, topicName);
+            List<Message> messages = buildMessage(request, schema, producerName, topicName, schemaVersion);
             List<CompletableFuture<Position>> publishResults = new ArrayList<>();
             List<ProducerAck> produceMessageResults = new ArrayList<>();
             for (int index = 0; index < messages.size(); index++) {
@@ -237,7 +237,7 @@ public class TopicsBase extends PersistentTopicsBase {
         try {
             String producerName = (null == request.getProducerName() || request.getProducerName().isEmpty())
                     ? defaultProducerName : request.getProducerName();
-            List<Message> messages = buildMessage(request, schema, producerName, topicName);
+            List<Message> messages = buildMessage(request, schema, producerName, topicName, schemaVersion);
             List<CompletableFuture<Position>> publishResults = new ArrayList<>();
             List<ProducerAck> produceMessageResults = new ArrayList<>();
             // Try to publish messages to all partitions this broker owns in round robin mode.
@@ -627,7 +627,7 @@ public class TopicsBase extends PersistentTopicsBase {
 
     // Build pulsar message from REST request.
     private List<Message> buildMessage(ProducerMessages producerMessages, Schema schema,
-                                       String producerName, TopicName topicName) {
+                                       String producerName, TopicName topicName, SchemaVersion schemaVersion) {
         List<ProducerMessage> messages;
         List<Message> pulsarMessages = new ArrayList<>();
 
@@ -637,11 +637,7 @@ public class TopicsBase extends PersistentTopicsBase {
             messageMetadata.setProducerName(producerName);
             messageMetadata.setPublishTime(System.currentTimeMillis());
             messageMetadata.setSequenceId(message.getSequenceId());
-            if (producerMessages.getSchemaVersion() != -1) {
-                LongSchemaVersion longSchemaVersion = new LongSchemaVersion(producerMessages.getSchemaVersion());
-                messageMetadata.setSchemaVersion(longSchemaVersion.bytes());
-            }
-
+            messageMetadata.setSchemaVersion(schemaVersion.bytes());
             if (null != message.getReplicationClusters()) {
                 messageMetadata.addAllReplicateTos(message.getReplicationClusters());
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
@@ -637,6 +637,11 @@ public class TopicsBase extends PersistentTopicsBase {
             messageMetadata.setProducerName(producerName);
             messageMetadata.setPublishTime(System.currentTimeMillis());
             messageMetadata.setSequenceId(message.getSequenceId());
+            if (producerMessages.getSchemaVersion() != -1) {
+                LongSchemaVersion longSchemaVersion = new LongSchemaVersion(producerMessages.getSchemaVersion());
+                messageMetadata.setSchemaVersion(longSchemaVersion.bytes());
+            }
+
             if (null != message.getReplicationClusters()) {
                 messageMetadata.addAllReplicateTos(message.getReplicationClusters());
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -33,7 +33,6 @@ import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -919,12 +919,16 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
             GenericJsonRecord genericJsonRecord = (GenericJsonRecord) msg.getValue();
             Assert.assertEquals(genericJsonRecord.getField("brand"), expected.get(i).getBrand());
             Assert.assertEquals(genericJsonRecord.getField("model"), expected.get(i).getModel());
-            Assert.assertEquals(genericJsonRecord.getField("year"), expected.get(i).getYear());
+            Number year = (Number) genericJsonRecord.getField("year");
+            Assert.assertEquals(year.intValue(), expected.get(i).getYear());
             Assert.assertEquals(genericJsonRecord.getField("gpu"), expected.get(i).getGpu().name());
-            Map<String, Object> seller = (Map<String, Object>) genericJsonRecord.getField("seller");
-            Assert.assertEquals(seller.get("state"), expected.get(i).getSeller().getState());
-            Assert.assertEquals(seller.get("street"), expected.get(i).getSeller().getStreet());
-            Assert.assertEquals(seller.get("zipCode"), expected.get(i).getSeller().getZipCode());
+            Object seller = genericJsonRecord.getField("seller");
+            Assert.assertTrue(seller instanceof GenericJsonRecord);
+            GenericJsonRecord sellerGenericJsonRecord = (GenericJsonRecord) seller;
+            Assert.assertEquals(sellerGenericJsonRecord.getField("state"), expected.get(i).getSeller().getState());
+            Assert.assertEquals(sellerGenericJsonRecord.getField("street"), expected.get(i).getSeller().getStreet());
+            Number zipCode = (Number) sellerGenericJsonRecord.getField("zipCode");
+            Assert.assertEquals(zipCode.longValue(), expected.get(i).getSeller().getZipCode());
         }
     }
 


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar/issues/24966

### Motivation

Add schema version support in rest produce api, which was ignored before.

### Modifications

Add schema version support in rest produce api and add unit test.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 

