### PR TITLE
[fix][admin] Use ClientConfigurationData timeout params to set AsyncHttpConnector timeout params

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1856,6 +1856,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     + ", webServiceAddress: " + webServiceAddress);
         }
         PulsarAdminBuilder builder = PulsarAdmin.builder().serviceHttpUrl(adminApiUrl);
+        // most of the admin request requires to make zk-call so, keep the max read-timeout based on
+        // zk-operation timeout. Put it before loading brokerClient_ prefix config, so user can override it
+        builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
 
         // Apply all arbitrary configuration. This must be called before setting any fields annotated as
         // @Secret on the ClientConfigurationData object because of the way they are serialized.
@@ -1887,9 +1890,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     .enableTlsHostnameVerification(conf.isTlsHostnameVerificationEnabled());
         }
 
-        // most of the admin request requires to make zk-call so, keep the max read-timeout based on
-        // zk-operation timeout
-        builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
         return builder;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1653,6 +1653,10 @@ public class BrokerService implements Closeable {
                 PulsarAdminBuilder builder = PulsarAdmin.builder();
 
                 ServiceConfiguration conf = pulsar.getConfig();
+                // most of the admin request requires to make zk-call so, keep the max read-timeout based on
+                // zk-operation timeout. Put it before loading brokerClient_ prefix config, so user can override it
+                builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
+
                 // Apply all arbitrary configuration. This must be called before setting any fields annotated as
                 // @Secret on the ClientConfigurationData object because of the way they are serialized.
                 // See https://github.com/apache/pulsar/issues/8509 for more information.
@@ -1707,10 +1711,6 @@ public class BrokerService implements Closeable {
                             conf.getBrokerClientSslFactoryPluginParams()
                     );
                 }
-
-                // most of the admin request requires to make zk-call so, keep the max read-timeout based on
-                // zk-operation timeout
-                builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
 
                 PulsarAdmin adminClient = builder.build();
                 log.info("created admin with url {} ", adminApiUrl);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -148,8 +147,6 @@ public class PulsarAdminImpl implements PulsarAdmin {
 
         ClientBuilder clientBuilder = ClientBuilder.newBuilder()
                 .withConfig(httpConfig)
-                .connectTimeout(this.clientConfigData.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS)
-                .readTimeout(this.clientConfigData.getReadTimeoutMs(), TimeUnit.MILLISECONDS)
                 .register(JacksonConfigurator.class).register(JacksonFeature.class);
 
         boolean useTls = clientConfigData.getServiceUrl().startsWith("https://");

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -53,7 +53,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import javax.ws.rs.ProcessingException;
-import javax.ws.rs.client.Client;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response.Status;
 import lombok.Data;
@@ -120,9 +119,8 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
     @Setter
     private boolean followRedirects = true;
 
-    public AsyncHttpConnector(Client client, ClientConfigurationData conf, int autoCertRefreshTimeSeconds,
+    public AsyncHttpConnector(ClientConfigurationData conf, int autoCertRefreshTimeSeconds,
                               boolean acceptGzipCompression) {
-        // client is not used, but we need to keep it for compatibility with old code
         this(conf.getConnectionTimeoutMs(), conf.getReadTimeoutMs(), conf.getRequestTimeoutMs(),
                 autoCertRefreshTimeSeconds, conf, acceptGzipCompression, null);
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -63,7 +63,6 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
 import org.apache.pulsar.PulsarVersion;
-import org.apache.pulsar.client.admin.internal.PulsarAdminImpl;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.PulsarClientSharedResourcesImpl;
 import org.apache.pulsar.client.impl.PulsarServiceNameResolver;
@@ -89,7 +88,6 @@ import org.asynchttpclient.Response;
 import org.asynchttpclient.SslEngineFactory;
 import org.asynchttpclient.channel.DefaultKeepAliveStrategy;
 import org.asynchttpclient.uri.Uri;
-import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.ClientRequest;
 import org.glassfish.jersey.client.ClientResponse;
 import org.glassfish.jersey.client.spi.AsyncConnectorCallback;
@@ -124,11 +122,9 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
 
     public AsyncHttpConnector(Client client, ClientConfigurationData conf, int autoCertRefreshTimeSeconds,
                               boolean acceptGzipCompression) {
-        this((int) client.getConfiguration().getProperty(ClientProperties.CONNECT_TIMEOUT),
-                (int) client.getConfiguration().getProperty(ClientProperties.READ_TIMEOUT),
-                PulsarAdminImpl.DEFAULT_REQUEST_TIMEOUT_SECONDS * 1000,
-                autoCertRefreshTimeSeconds,
-                conf, acceptGzipCompression, null);
+        // client is not used, but we need to keep it for compatibility with old code
+        this(conf.getConnectionTimeoutMs(), conf.getReadTimeoutMs(), conf.getRequestTimeoutMs(),
+                autoCertRefreshTimeSeconds, conf, acceptGzipCompression, null);
     }
 
     @SneakyThrows
@@ -220,7 +216,6 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
         confBuilder.setCookieStore(null);
         confBuilder.setUseProxyProperties(true);
         confBuilder.setFollowRedirect(false);
-        confBuilder.setRequestTimeout(conf.getRequestTimeoutMs());
         confBuilder.setConnectTimeout(connectTimeoutMs);
         confBuilder.setReadTimeout(readTimeoutMs);
         confBuilder.setUserAgent(String.format("Pulsar-Java-v%s%s",

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnectorProvider.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnectorProvider.java
@@ -47,7 +47,7 @@ public class AsyncHttpConnectorProvider implements ConnectorProvider {
     @Override
     public Connector getConnector(Client client, Configuration runtimeConfig) {
         if (connector == null) {
-            connector = new AsyncHttpConnector(client, conf, autoCertRefreshTimeSeconds, acceptGzipCompression);
+            connector = new AsyncHttpConnector(conf, autoCertRefreshTimeSeconds, acceptGzipCompression);
             connector.setFollowRedirects(followRedirects);
         }
         return connector;

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminImplTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminImplTest.java
@@ -28,7 +28,6 @@ import static org.testng.Assert.assertEquals;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
-import java.io.IOException;
 import java.util.List;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
@@ -50,7 +49,7 @@ public class PulsarAdminImplTest {
     WireMockServer server;
 
     @BeforeClass(alwaysRun = true)
-    void beforeClass() throws IOException {
+    void beforeClass() {
         server = new WireMockServer(WireMockConfiguration.wireMockConfig()
                 .port(0));
         server.start();
@@ -113,8 +112,7 @@ public class PulsarAdminImplTest {
         @Cleanup
         PulsarAdminImpl admin = new PulsarAdminImpl(conf.getServiceUrl(), conf, null);
         List<String> clusters = admin.clusters().getClusters();
-        assertThat(clusters).hasSize(1);
-        assertThat(clusters).contains("test-cluster");
+        assertThat(clusters).containsOnly("test-cluster");
 
         server.verify(1, getRequestedFor(urlEqualTo("/admin/v2/clusters")));
         String scenarioState = server.getAllScenarios().getScenarios().stream()
@@ -190,8 +188,7 @@ public class PulsarAdminImplTest {
         @Cleanup
         PulsarAdminImpl admin = new PulsarAdminImpl(conf.getServiceUrl(), conf, null);
         List<String> clusters = admin.clusters().getClusters();
-        assertThat(clusters).hasSize(1);
-        assertThat(clusters).contains("test-cluster");
+        assertThat(clusters).containsOnly("test-cluster");
 
         server.verify(2, getRequestedFor(urlEqualTo("/admin/v2/clusters")));
         String scenarioState = server.getAllScenarios().getScenarios().stream()

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminImplTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminImplTest.java
@@ -18,18 +18,55 @@
  */
 package org.apache.pulsar.client.admin.internal;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import java.io.IOException;
+import java.util.List;
+import lombok.Cleanup;
 import lombok.SneakyThrows;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
  * Unit tests for {@link PulsarAdminImpl}.
  */
 public class PulsarAdminImplTest {
+
+    WireMockServer server;
+
+    @BeforeClass(alwaysRun = true)
+    void beforeClass() throws IOException {
+        server = new WireMockServer(WireMockConfiguration.wireMockConfig()
+                .port(0));
+        server.start();
+    }
+
+    @AfterClass(alwaysRun = true)
+    void afterClass() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @BeforeMethod
+    public void beforeEach() {
+        server.resetAll();
+    }
 
     @Test
     public void testAuthDisabledWhenAuthNotSpecifiedAnywhere() {
@@ -51,4 +88,166 @@ public class PulsarAdminImplTest {
             return admin.auth;
         }
     }
+
+    @Test
+    @SneakyThrows
+    public void testPulsarAdminAsyncHttpConnectorSuccessWithoutRetry() {
+        int readTimeoutMs = 5000;
+        int serverDelayMs = 3000;
+        server.stubFor(get(urlEqualTo("/admin/v2/clusters"))
+                .inScenario("read-success-without-retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willSetStateTo("success")
+                .willReturn(ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[\"test-cluster\"]")
+                        .withFixedDelay(serverDelayMs)));
+
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("http://localhost:" + server.port());
+        conf.setConnectionTimeoutMs(2000);
+        conf.setReadTimeoutMs(readTimeoutMs);
+        conf.setRequestTimeoutMs(-1);
+
+        @Cleanup
+        PulsarAdminImpl admin = new PulsarAdminImpl(conf.getServiceUrl(), conf, null);
+        List<String> clusters = admin.clusters().getClusters();
+        assertThat(clusters).hasSize(1);
+        assertThat(clusters).contains("test-cluster");
+
+        server.verify(1, getRequestedFor(urlEqualTo("/admin/v2/clusters")));
+        String scenarioState = server.getAllScenarios().getScenarios().stream()
+                .filter(scenario -> "read-success-without-retry".equals(scenario.getName())).findFirst().get()
+                .getState();
+        assertEquals(scenarioState, "success");
+    }
+
+    @Test
+    @SneakyThrows
+    public void testPulsarAdminAsyncHttpConnectorTimeoutWithoutRetry() {
+        int readTimeoutMs = 5000;
+        int serverDelayMs = 8000;
+
+        server.stubFor(get(urlEqualTo("/admin/v2/clusters"))
+                .inScenario("read-timeout-without-retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willSetStateTo("end")
+                .willReturn(ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[\"test-cluster\"]")
+                        .withFixedDelay(serverDelayMs)));
+
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("http://localhost:" + server.port());
+        conf.setConnectionTimeoutMs(2000);
+        conf.setReadTimeoutMs(readTimeoutMs);
+        conf.setRequestTimeoutMs(-1);
+
+        @Cleanup
+        PulsarAdminImpl admin = new PulsarAdminImpl(conf.getServiceUrl(), conf, null);
+        Assert.expectThrows(PulsarAdminException.TimeoutException.class, () -> {
+            admin.clusters().getClusters();
+        });
+
+        server.verify(1, getRequestedFor(urlEqualTo("/admin/v2/clusters")));
+        String scenarioState = server.getAllScenarios().getScenarios().stream()
+                .filter(scenario -> "read-timeout-without-retry".equals(scenario.getName())).findFirst().get()
+                .getState();
+        assertEquals(scenarioState, "end");
+    }
+
+    @Test
+    @SneakyThrows
+    public void testPulsarAdminAsyncHttpConnectorSuccessWithRetry() {
+        int readTimeoutMs = 5000;
+        int requestTimeoutMs = 10000;
+        int serverDelayMs = 7000;
+        server.stubFor(get(urlEqualTo("/admin/v2/clusters"))
+                .inScenario("read-success-with-retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willSetStateTo("first-call")
+                .willReturn(ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[\"test-cluster\"]")
+                        .withFixedDelay(serverDelayMs)));
+
+        server.stubFor(get(urlEqualTo("/admin/v2/clusters"))
+                .inScenario("read-success-with-retry")
+                .whenScenarioStateIs("first-call")
+                .willSetStateTo("success")
+                .willReturn(ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[\"test-cluster\"]")));
+
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("http://localhost:" + server.port());
+        conf.setConnectionTimeoutMs(2000);
+        conf.setReadTimeoutMs(readTimeoutMs);
+        conf.setRequestTimeoutMs(requestTimeoutMs);
+
+        @Cleanup
+        PulsarAdminImpl admin = new PulsarAdminImpl(conf.getServiceUrl(), conf, null);
+        List<String> clusters = admin.clusters().getClusters();
+        assertThat(clusters).hasSize(1);
+        assertThat(clusters).contains("test-cluster");
+
+        server.verify(2, getRequestedFor(urlEqualTo("/admin/v2/clusters")));
+        String scenarioState = server.getAllScenarios().getScenarios().stream()
+                .filter(scenario -> "read-success-with-retry".equals(scenario.getName())).findFirst().get()
+                .getState();
+        assertEquals(scenarioState, "success");
+    }
+
+    @Test
+    @SneakyThrows
+    public void testPulsarAdminAsyncHttpConnectorTimeoutWithRetry() {
+        int readTimeoutMs = 5000;
+        int requestTimeoutMs = 14000;
+        int serverDelayMs = 6000;
+        server.stubFor(get(urlEqualTo("/admin/v2/clusters"))
+                .inScenario("read-timeout-with-retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willSetStateTo("first-call")
+                .willReturn(ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[\"test-cluster\"]")
+                        .withFixedDelay(serverDelayMs)));
+
+        server.stubFor(get(urlEqualTo("/admin/v2/clusters"))
+                .inScenario("read-timeout-with-retry")
+                .whenScenarioStateIs("first-call")
+                .willSetStateTo("second-call")
+                .willReturn(ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[\"test-cluster\"]")
+                        .withFixedDelay(serverDelayMs)));
+
+        server.stubFor(get(urlEqualTo("/admin/v2/clusters"))
+                .inScenario("read-timeout-with-retry")
+                .whenScenarioStateIs("second-call")
+                .willSetStateTo("end")
+                .willReturn(ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[\"test-cluster\"]")
+                        .withFixedDelay(serverDelayMs)));
+
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("http://localhost:" + server.port());
+        conf.setConnectionTimeoutMs(2000);
+        conf.setReadTimeoutMs(readTimeoutMs);
+        conf.setRequestTimeoutMs(requestTimeoutMs);
+
+        @Cleanup
+        PulsarAdminImpl admin = new PulsarAdminImpl(conf.getServiceUrl(), conf, null);
+        Assert.expectThrows(PulsarAdminException.TimeoutException.class, () -> {
+            admin.clusters().getClusters();
+        });
+
+        server.verify(3, getRequestedFor(urlEqualTo("/admin/v2/clusters")));
+        String scenarioState = server.getAllScenarios().getScenarios().stream()
+                .filter(scenario -> "read-timeout-with-retry".equals(scenario.getName())).findFirst().get()
+                .getState();
+        assertEquals(scenarioState, "end");
+    }
+
 }

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminImplTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminImplTest.java
@@ -93,6 +93,7 @@ public class PulsarAdminImplTest {
     @SneakyThrows
     public void testPulsarAdminAsyncHttpConnectorSuccessWithoutRetry() {
         int readTimeoutMs = 5000;
+        int requestTimeoutMs = 5000;
         int serverDelayMs = 3000;
         server.stubFor(get(urlEqualTo("/admin/v2/clusters"))
                 .inScenario("read-success-without-retry")
@@ -107,7 +108,7 @@ public class PulsarAdminImplTest {
         conf.setServiceUrl("http://localhost:" + server.port());
         conf.setConnectionTimeoutMs(2000);
         conf.setReadTimeoutMs(readTimeoutMs);
-        conf.setRequestTimeoutMs(-1);
+        conf.setRequestTimeoutMs(requestTimeoutMs);
 
         @Cleanup
         PulsarAdminImpl admin = new PulsarAdminImpl(conf.getServiceUrl(), conf, null);
@@ -126,6 +127,7 @@ public class PulsarAdminImplTest {
     @SneakyThrows
     public void testPulsarAdminAsyncHttpConnectorTimeoutWithoutRetry() {
         int readTimeoutMs = 5000;
+        int requestTimeoutMs = 5000;
         int serverDelayMs = 8000;
 
         server.stubFor(get(urlEqualTo("/admin/v2/clusters"))
@@ -141,7 +143,7 @@ public class PulsarAdminImplTest {
         conf.setServiceUrl("http://localhost:" + server.port());
         conf.setConnectionTimeoutMs(2000);
         conf.setReadTimeoutMs(readTimeoutMs);
-        conf.setRequestTimeoutMs(-1);
+        conf.setRequestTimeoutMs(requestTimeoutMs);
 
         @Cleanup
         PulsarAdminImpl admin = new PulsarAdminImpl(conf.getServiceUrl(), conf, null);


### PR DESCRIPTION
### Motivation

In previous code, we use `client.getConfiguration().getProperty(ClientProperties.CONNECT_TIMEOUT)` as PulsarAdmin's `connectionTimeoutMs`, use `client.getConfiguration().getProperty(ClientProperties.READ_TIMEOUT)` as PulsarAdmin's `readTimeoutMs`, use `PulsarAdminImpl.DEFAULT_REQUEST_TIMEOUT_SECONDS * 1000` as PulsarAdmin's `requestTimeoutMs`. See:

https://github.com/apache/pulsar/blob/b71bea4c42353f9d14f817aa9a0877d495336f34/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java#L121-L128

Before this PR, we can't tune `requestTimeoutMs`, which is always 30000s = 5min. See also in: 

https://github.com/apache/pulsar/issues/24879#issuecomment-3440341666

### Modifications

Now, we use `ClientConfigurationData.requestTimeoutMs` as `AsyncHttpConnector.requestTimeoutMs` , so we can control the http retry timeout by tuning `ClientConfigurationData.requestTimeoutMs`.

AsyncHttpClient get Connector by calling `ConnectorProvider#getConnector(Client client, Configuration runtimeConfig)` method.

https://github.com/eclipse-ee4j/jersey/blob/bb8a2a1b78e39604f4d283d0176705b143355cce/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java#L465-L467

Both `connectionTimeoutMs` and `readTimeoutMs` are the same values in jersey properties and `ClientConfigurationData`. See: 

https://github.com/apache/pulsar/blob/b71bea4c42353f9d14f817aa9a0877d495336f34/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java#L146-L150

To ensure code consistency, I would like to suggest using `ClientConfigurationData` and removing jersey config.

Side effect: default `requestTimeoutMs` changes from 30s to 60s after this PR, which I think is reasonable. If I didn't read the source code, I would assume `requestTimeoutMs` is set to 60s, and it would confuse me to find that `requestTimeoutMs` didn't take effect after I adjusted this value.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
