### PR TITLE
[fix][client] Fix invalid parameter type passed to Map.get in TopicsImpl.getListAsync method 

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -91,6 +91,7 @@ import org.apache.pulsar.broker.testcontext.MockEntryFilterProvider;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.GrantTopicPermissionOptions;
 import org.apache.pulsar.client.admin.ListNamespaceTopicsOptions;
+import org.apache.pulsar.client.admin.ListTopicsOptions;
 import org.apache.pulsar.client.admin.Mode;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -1269,9 +1270,29 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
             }
         }
 
-        Set<String> topicsInNs = Sets
-                .newHashSet(
-                        admin.topics().getList(namespace, null, Collections.singletonMap(QueryParam.Bundle, bundle)));
+        Set<String> topicsInNs;
+        // 1. test recommended sync method
+        ListTopicsOptions listTopicsOptions = ListTopicsOptions.builder().bundle(bundle).build();
+        topicsInNs = Sets.newHashSet(admin.topics().getList(namespace, null, listTopicsOptions));
+        assertEquals(topicsInNs.size(), topics.size());
+        topicsInNs.removeAll(topics);
+        assertEquals(topicsInNs.size(), 0);
+
+        // 2. test recommended async method
+        topicsInNs = Sets.newHashSet(admin.topics().getListAsync(namespace, null, listTopicsOptions).get());
+        assertEquals(topicsInNs.size(), topics.size());
+        topicsInNs.removeAll(topics);
+        assertEquals(topicsInNs.size(), 0);
+
+        // 3. test deprecated sync method
+        Map<QueryParam, Object> queryOption = Collections.singletonMap(QueryParam.Bundle, bundle);
+        topicsInNs = Sets.newHashSet(admin.topics().getList(namespace, null, queryOption));
+        assertEquals(topicsInNs.size(), topics.size());
+        topicsInNs.removeAll(topics);
+        assertEquals(topicsInNs.size(), 0);
+
+        // 4. test deprecated async method
+        topicsInNs = Sets.newHashSet(admin.topics().getListAsync(namespace, null, queryOption).get());
         assertEquals(topicsInNs.size(), topics.size());
         topicsInNs.removeAll(topics);
         assertEquals(topicsInNs.size(), 0);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -184,7 +184,7 @@ public class TopicsImpl extends BaseResource implements Topics {
                                                         Map<QueryParam, Object> params) {
         ListTopicsOptions options = ListTopicsOptions
                 .builder()
-                .bundle((String) params.get(QueryParam.Bundle.value))
+                .bundle((String) params.get(QueryParam.Bundle))
                 .build();
         return getListAsync(namespace, topicDomain, options);
     }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/25060

### Motivation

See issue's description: `TopicsImpl#getListAsync(String namespace, TopicDomain topicDomain, Map<QueryParam, Object> params))` method passes invalid parameter type to `Map.get()`.

As this is an admin client Topics API method, we should keep this method despite being marked as deprecated, because the specific version for its removal has not been specified.

### Modifications

Add unit test to reproduce the issue, and pass the correct param type to `Map.get()`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
