### PR TITLE
[improve][admin] Add counter for marker messages in PersistentTopics.analyzeSubscriptionBacklog() rest api

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1693,6 +1693,7 @@ public class PersistentTopicsBase extends AdminResource {
 
                         result.setEntries(rawResult.getEntries());
                         result.setMessages(rawResult.getMessages());
+                        result.setMarkerMessages(rawResult.getMarkerMessages());
 
                         result.setFilterAcceptedEntries(rawResult.getFilterAcceptedEntries());
                         result.setFilterRejectedEntries(rawResult.getFilterRejectedEntries());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AnalyzeBacklogResult.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AnalyzeBacklogResult.java
@@ -29,6 +29,7 @@ public final class AnalyzeBacklogResult {
 
     private long entries;
     private long messages;
+    private long markerMessages;
 
     private long filterRejectedEntries;
     private long filterAcceptedEntries;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -720,6 +720,7 @@ public class PersistentSubscription extends AbstractSubscription {
             result.setLastPosition(lastPosition.get());
             result.setEntries(entries.get());
             result.setMessages(messages.get());
+            result.setMarkerMessages(markerMessages.get());
             result.setFilterAcceptedEntries(accepted.get());
             result.setFilterAcceptedMessages(acceptedMessages.get());
             result.setFilterRejectedEntries(rejected.get());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -668,6 +668,10 @@ public class PersistentSubscription extends AbstractSubscription {
             } else {
                 messageMetadata = Commands.peekMessageMetadata(metadataAndPayload, "", -1);
             }
+            if (messageMetadata.hasMarkerType()) {
+                markerMessages.incrementAndGet();
+                return true;
+            }
             int numMessages = 1;
             if (messageMetadata.hasNumMessagesInBatch()) {
                 numMessages = messageMetadata.getNumMessagesInBatch();
@@ -694,9 +698,6 @@ public class PersistentSubscription extends AbstractSubscription {
             }
             long num = entries.incrementAndGet();
             messages.addAndGet(numMessages);
-            if (messageMetadata.hasMarkerType()) {
-                markerMessages.addAndGet(numMessages);
-            }
 
             if (num % 1000 == 0) {
                 long end = System.currentTimeMillis();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -635,6 +635,7 @@ public class PersistentSubscription extends AbstractSubscription {
         AtomicLong rejected = new AtomicLong();
         AtomicLong rescheduled = new AtomicLong();
         AtomicLong messages = new AtomicLong();
+        AtomicLong markerMessages = new AtomicLong();
         AtomicLong acceptedMessages = new AtomicLong();
         AtomicLong rejectedMessages = new AtomicLong();
         AtomicLong rescheduledMessages = new AtomicLong();
@@ -693,6 +694,9 @@ public class PersistentSubscription extends AbstractSubscription {
             }
             long num = entries.incrementAndGet();
             messages.addAndGet(numMessages);
+            if (messageMetadata.hasMarkerType()) {
+                markerMessages.addAndGet(numMessages);
+            }
 
             if (num % 1000 == 0) {
                 long end = System.currentTimeMillis();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AnalyzeBacklogSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AnalyzeBacklogSubscriptionTest.java
@@ -161,6 +161,7 @@ public class AnalyzeBacklogSubscriptionTest extends ProducerConsumerBase {
         assertEquals(analyzeSubscriptionBacklogResult.getFilterRescheduledEntries(), 0);
 
         assertEquals(analyzeSubscriptionBacklogResult.getMessages(), numMessages);
+        assertEquals(analyzeSubscriptionBacklogResult.getMarkerMessages(), 0);
         assertEquals(analyzeSubscriptionBacklogResult.getFilterAcceptedMessages(), numMessages);
         assertEquals(analyzeSubscriptionBacklogResult.getFilterRejectedMessages(), 0);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -1081,7 +1081,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         MessageId committedMiddleMsgId = committedMsgIds.get(numMessages / 2);
         backlogResult =
                 admin.topics().analyzeSubscriptionBacklog(topic, transactionSubName, Optional.of(committedMiddleMsgId));
-        assertEquals(backlogResult.getMessages(), (numMessages / 2) + numMessages);
+        assertEquals(backlogResult.getMessages(), numMessages);
         assertEquals(backlogResult.getMarkerMessages(), numMessages / 2);
 
         List<MessageId> abortedMsgIds = new ArrayList<>();
@@ -1098,7 +1098,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         MessageId abortedMiddleMsgId = abortedMsgIds.get(numMessages / 2);
         backlogResult =
                 admin.topics().analyzeSubscriptionBacklog(topic, transactionSubName, Optional.of(abortedMiddleMsgId));
-        assertEquals(backlogResult.getMessages(), (numMessages / 2) + numMessages);
+        assertEquals(backlogResult.getMessages(), numMessages);
         assertEquals(backlogResult.getMarkerMessages(), numMessages / 2);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -1077,13 +1077,13 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
 
         AnalyzeSubscriptionBacklogResult backlogResult =
                 admin.topics().analyzeSubscriptionBacklog(topic, transactionSubName, Optional.empty());
-        assertEquals(backlogResult.getMessages(), numMessages * 2);
+        assertEquals(backlogResult.getMessages(), numMessages);
         assertEquals(backlogResult.getMarkerMessages(), numMessages);
 
         MessageId committedMiddleMsgId = committedMsgIds.get(numMessages / 2);
         backlogResult =
                 admin.topics().analyzeSubscriptionBacklog(topic, transactionSubName, Optional.of(committedMiddleMsgId));
-        assertEquals(backlogResult.getMessages(), numMessages);
+        assertEquals(backlogResult.getMessages(), numMessages / 2);
         assertEquals(backlogResult.getMarkerMessages(), numMessages / 2);
 
         List<MessageId> abortedMsgIds = new ArrayList<>();
@@ -1094,13 +1094,13 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
             txn.abort();
         }
         backlogResult = admin.topics().analyzeSubscriptionBacklog(topic, transactionSubName, Optional.empty());
-        assertEquals(backlogResult.getMessages(), numMessages * 4);
+        assertEquals(backlogResult.getMessages(), numMessages * 2);
         assertEquals(backlogResult.getMarkerMessages(), numMessages * 2);
 
         MessageId abortedMiddleMsgId = abortedMsgIds.get(numMessages / 2);
         backlogResult =
                 admin.topics().analyzeSubscriptionBacklog(topic, transactionSubName, Optional.of(abortedMiddleMsgId));
-        assertEquals(backlogResult.getMessages(), numMessages);
+        assertEquals(backlogResult.getMessages(), numMessages / 2);
         assertEquals(backlogResult.getMarkerMessages(), numMessages / 2);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -1058,9 +1058,11 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testAnalyzeSubscriptionBacklogWithTransactionMarker() throws Exception {
         initTransaction(1);
-        final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/analyze_subscription_backlog");
-        String transactionSubName = "analyze_subscription_backlog-topic-sub";
+        final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/analyze-subscription-backlog");
+        String transactionSubName = "analyze-subscription-backlog-topic-sub";
 
+        // Init subscription and then close the consumer. If consumer is connected and has available permits,
+        // AbstractBaseDispatcher#filterEntriesForConsumer will auto ack marker messages
         pulsarClient.newConsumer(Schema.STRING).topic(topic).subscriptionName(transactionSubName).subscribe().close();
         @Cleanup Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -1065,11 +1065,10 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         @Cleanup Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
 
         int numMessages = 10;
-        String committedMsgPrefix = "commited-msg";
         List<MessageId> committedMsgIds = new ArrayList<>();
         for (int i = 0; i < numMessages; i++) {
             Transaction txn = pulsarClient.newTransaction().build().get();
-            MessageId messageId = producer.newMessage(txn).value(committedMsgPrefix + i).send();
+            MessageId messageId = producer.newMessage(txn).value("commited-msg" + i).send();
             committedMsgIds.add(messageId);
             txn.commit().get();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -1102,6 +1102,14 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
                 admin.topics().analyzeSubscriptionBacklog(topic, transactionSubName, Optional.of(abortedMiddleMsgId));
         assertEquals(backlogResult.getMessages(), numMessages / 2);
         assertEquals(backlogResult.getMarkerMessages(), numMessages / 2);
+
+        Transaction txn = pulsarClient.newTransaction().build().get();
+        for (int i = 0; i < numMessages; i++) {
+            producer.newMessage(txn).value("uncommitted-msg-" + i).send();
+        }
+        backlogResult = admin.topics().analyzeSubscriptionBacklog(topic, transactionSubName, Optional.empty());
+        assertEquals(backlogResult.getMessages(), numMessages * 3);
+        assertEquals(backlogResult.getMarkerMessages(), numMessages * 2);
     }
 
     private static void verifyCoordinatorStats(String state,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -1058,11 +1058,10 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testAnalyzeSubscriptionBacklogWithTransactionMarker() throws Exception {
         initTransaction(1);
-        final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/peek_all");
-        String transactionSubName = "transaction-topic-sub";
+        final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/analyze_subscription_backlog");
+        String transactionSubName = "analyze_subscription_backlog-topic-sub";
 
-        @Cleanup Consumer<String> consumer =
-                pulsarClient.newConsumer(Schema.STRING).topic(topic).subscriptionName(transactionSubName).subscribe();
+        pulsarClient.newConsumer(Schema.STRING).topic(topic).subscriptionName(transactionSubName).subscribe().close();
         @Cleanup Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
 
         int numMessages = 10;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatedSubscriptionTest.java
@@ -1095,7 +1095,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
         // Assert analyze backlog total messages and marker messages.
         AnalyzeSubscriptionBacklogResult backlogResult =
                 admin4.topics().analyzeSubscriptionBacklog(topicName, subscriptionName, Optional.empty());
-        assertEquals(backlogResult.getMessages(), numMessages + numSnapshotRequest);
+        assertEquals(backlogResult.getMessages(), numMessages);
         assertEquals(backlogResult.getMarkerMessages(), numSnapshotRequest);
 
         // Wait pending snapshot timeout

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatedSubscriptionTest.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
@@ -70,6 +71,7 @@ import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
+import org.apache.pulsar.common.stats.AnalyzeSubscriptionBacklogResult;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1089,6 +1091,12 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
             }
         }
         Assert.assertEquals(numSnapshotRequest, 1);
+
+        // Assert analyze backlog total messages and marker messages.
+        AnalyzeSubscriptionBacklogResult backlogResult =
+                admin4.topics().analyzeSubscriptionBacklog(topicName, subscriptionName, Optional.empty());
+        assertEquals(backlogResult.getMessages(), numMessages + numSnapshotRequest);
+        assertEquals(backlogResult.getMarkerMessages(), numSnapshotRequest);
 
         // Wait pending snapshot timeout
         Thread.sleep(config1.getReplicatedSubscriptionsSnapshotTimeoutSeconds() * 1000);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/FilterEntryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/FilterEntryTest.java
@@ -253,7 +253,7 @@ public class FilterEntryTest extends BrokerTestBase {
             producer.send("test");
         }
 
-        verifyBacklog(topic, subName, 10, 10, 10, 10, 0, 0, 0, 0);
+        verifyBacklog(topic, subName, 10, 10, 0, 10, 10, 0, 0, 0, 0);
 
         int counter = 0;
         while (true) {
@@ -268,7 +268,7 @@ public class FilterEntryTest extends BrokerTestBase {
         // All normal messages can be received
         assertEquals(10, counter);
 
-        verifyBacklog(topic, subName, 0, 0, 0, 0, 0, 0, 0, 0);
+        verifyBacklog(topic, subName, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
         // stop the consumer
         consumer.close();
@@ -280,7 +280,7 @@ public class FilterEntryTest extends BrokerTestBase {
 
         // analyze the subscription and predict that
         // 10 messages will be rejected by the filter
-        verifyBacklog(topic, subName, 10, 10, 0, 0, 10, 10, 0, 0);
+        verifyBacklog(topic, subName, 10, 10, 0, 0, 0, 10, 10, 0, 0);
 
         consumer = pulsarClient.newConsumer(Schema.STRING)
                 .topic(topic)
@@ -304,7 +304,7 @@ public class FilterEntryTest extends BrokerTestBase {
 
         // now the Filter acknoledged the messages on behalf of the Consumer
         // backlog is now zero again
-        verifyBacklog(topic, subName, 0, 0, 0, 0, 0, 0, 0, 0);
+        verifyBacklog(topic, subName, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
         // All messages should be acked, check the MarkDeletedPosition
         assertNotNull(lastMsgId);
@@ -545,7 +545,7 @@ public class FilterEntryTest extends BrokerTestBase {
 
 
     private void verifyBacklog(String topic, String subscription,
-                               int numEntries, int numMessages,
+                               int numEntries, int numMessages, int numMarkerMessages,
                                int numEntriesAccepted, int numMessagesAccepted,
                                int numEntriesRejected, int numMessagesRejected,
                                int numEntriesRescheduled, int numMessagesRescheduled
@@ -559,6 +559,7 @@ public class FilterEntryTest extends BrokerTestBase {
         Assert.assertEquals(numEntriesRescheduled, a1.getFilterRescheduledEntries());
 
         Assert.assertEquals(numMessages, a1.getMessages());
+        Assert.assertEquals(numMarkerMessages, a1.getMarkerMessages());
         Assert.assertEquals(numMessagesAccepted, a1.getFilterAcceptedMessages());
         Assert.assertEquals(numMessagesRejected, a1.getFilterRejectedMessages());
         Assert.assertEquals(numMessagesRescheduled, a1.getFilterRescheduledMessages());

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/stats/AnalyzeSubscriptionBacklogResult.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/stats/AnalyzeSubscriptionBacklogResult.java
@@ -26,6 +26,7 @@ import lombok.ToString;
 public class AnalyzeSubscriptionBacklogResult {
     private long entries;
     private long messages;
+    private long markerMessages;
 
     private long filterRejectedEntries;
     private long filterAcceptedEntries;


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/25082

### Motivation

`PersistentTopics.analyzeSubscriptionBacklog()` rest api returns the counters of backlog, but the counters don't return the amount of marker messages.

### Modifications

Add counter for marker messages in `PersistentTopics.analyzeSubscriptionBacklog()` rest api, add tests.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
