### PR TITLE
[fix][test] Fix ManagedCursorTest.asyncMarkDeleteBlocking() flaky test

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2727,7 +2727,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     log.debug("No need to reset cursor: {}, current ledger is the last ledger.", cursor);
                 }
             } else {
-                // TODO no ledger exists, should we move cursor mark deleted position to nextPointedLedger:-1
+                // TODO no ledger exists, should we move cursor mark deleted position to nextPointedLedger:-1 ?
                 log.warn("Cursor: {} does not exist in the managed-ledger.", cursor);
             }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2717,6 +2717,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             LedgerInfo nextPointedLedger = Optional.ofNullable(ledgers.higherEntry(lastAckedPosition.getLedgerId()))
                     .map(Map.Entry::getValue).orElse(null);
 
+            // TODO If PR https://github.com/apache/pulsar/pull/25087 is needed,
+            //  may choose one of the following solutions:
+            //   1. Remove if (curPointedLedger != null)  check, moving cursor to nextPointedLedgerId:-1 is not needed.
+            //   2. Make maybeUpdateCursorBeforeTrimmingConsumedLedger a callback method too to avoid race condition.
             if (curPointedLedger != null) {
                 if (nextPointedLedger != null) {
                     if (lastAckedPosition.getEntryId() != -1
@@ -2734,7 +2738,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             if (lastAckedPosition.compareTo(cursor.getMarkDeletedPosition()) > 0) {
                 Position finalPosition = lastAckedPosition;
                 log.info("Reset cursor:{} to {} since ledger consumed completely", cursor, lastAckedPosition);
-                // TODO since this is an async method, should we make the caller a callback method too?
                 cursor.asyncMarkDelete(lastAckedPosition, cursor.getProperties(),
                     new MarkDeleteCallback() {
                         @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2717,10 +2717,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             LedgerInfo nextPointedLedger = Optional.ofNullable(ledgers.higherEntry(lastAckedPosition.getLedgerId()))
                     .map(Map.Entry::getValue).orElse(null);
 
-            // TODO If PR https://github.com/apache/pulsar/pull/25087 is needed,
-            //  may choose one of the following solutions:
-            //   1. Remove if (curPointedLedger != null)  check, moving cursor to nextPointedLedgerId:-1 is not needed.
-            //   2. Make maybeUpdateCursorBeforeTrimmingConsumedLedger a callback method too to avoid race condition.
             if (curPointedLedger != null) {
                 if (nextPointedLedger != null) {
                     if (lastAckedPosition.getEntryId() != -1
@@ -2738,6 +2734,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             if (lastAckedPosition.compareTo(cursor.getMarkDeletedPosition()) > 0) {
                 Position finalPosition = lastAckedPosition;
                 log.info("Reset cursor:{} to {} since ledger consumed completely", cursor, lastAckedPosition);
+                // TODO If PR https://github.com/apache/pulsar/pull/25087 is needed, maybe we should make
+                // maybeUpdateCursorBeforeTrimmingConsumedLedger a callback method too to avoid race condition.
                 cursor.asyncMarkDelete(lastAckedPosition, cursor.getProperties(),
                     new MarkDeleteCallback() {
                         @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2727,14 +2727,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     log.debug("No need to reset cursor: {}, current ledger is the last ledger.", cursor);
                 }
             } else {
-                // todo: no ledger exists, should we move cursor mark deleted position to nextPointedLedger:-1
+                // TODO no ledger exists, should we move cursor mark deleted position to nextPointedLedger:-1
                 log.warn("Cursor: {} does not exist in the managed-ledger.", cursor);
             }
 
             if (lastAckedPosition.compareTo(cursor.getMarkDeletedPosition()) > 0) {
                 Position finalPosition = lastAckedPosition;
                 log.info("Reset cursor:{} to {} since ledger consumed completely", cursor, lastAckedPosition);
-                // todo since this is an async method, should we make the caller a callback method too?
+                // TODO since this is an async method, should we make the caller a callback method too?
                 cursor.asyncMarkDelete(lastAckedPosition, cursor.getProperties(),
                     new MarkDeleteCallback() {
                         @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -1284,8 +1284,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         assertEquals(c1.getMarkDeletedPosition(), p1);
         ManagedCursor finalC2 = c2;
-        Awaitility.await()
-                .untilAsserted(() -> assertEquals(finalC2.getMarkDeletedPosition(), PositionFactory.create(6, -1)));
+        Awaitility.await().untilAsserted(() -> assertTrue(finalC2.getMarkDeletedPosition().compareTo(p2) > 0));
     }
 
     @Test(timeOut = 20000)
@@ -1418,14 +1417,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         //    move markDeletePosition to (lastPositionLegderId+3:-1)
         // See PR https://github.com/apache/pulsar/pull/25087.
         log.info("c2 markDeletePosition: {}, lastPosition: {}", c2.getMarkDeletedPosition(), lastPosition);
-        long lastPositionLedgerId = lastPosition.get().getLedgerId();
-        Awaitility.await().untilAsserted(() ->
-                assertTrue(
-                        c2.getMarkDeletedPosition().equals(lastPosition.get())
-                        || c2.getMarkDeletedPosition().equals(PositionFactory.create(lastPositionLedgerId + 2, -1))
-                        || c2.getMarkDeletedPosition().equals(PositionFactory.create(lastPositionLedgerId + 3, -1))
-                )
-        );
+        Awaitility.await()
+                .untilAsserted(() -> assertTrue(c2.getMarkDeletedPosition().compareTo(lastPosition.get()) >= 0));
     }
 
     @Test(timeOut = 20000)
@@ -1464,7 +1457,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
             }, null);
         }
         addEntryLatch.await();
-        assertEquals(lastPosition.get(), PositionFactory.create(13, 0));
 
         // If we set num=100, to avoid flaky test, we should add Thread.sleep(1000) here to make sure ledger rollover
         // is finished, but this sleep can not guarantee c1 always recovered with markDeletePosition 12:9.
@@ -1513,7 +1505,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // To make sure ManagedLedgerImpl.maybeUpdateCursorBeforeTrimmingConsumedLedger() is completed, we should
         // wait until c2.getMarkDeletedPosition() equals 15:-1, see PR https://github.com/apache/pulsar/pull/25087.
         Awaitility.await()
-                .untilAsserted(() -> assertEquals(c2.getMarkDeletedPosition(), PositionFactory.create(15, -1)));
+                .untilAsserted(() -> assertTrue(c2.getMarkDeletedPosition().compareTo(lastPosition.get()) > 0));
     }
 
     @Test(timeOut = 20000)
@@ -1563,10 +1555,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // the last c1.asyncMarkDelete() operation may trigger a cursor ledger rollover
         // See PR https://github.com/apache/pulsar/pull/25087.
         log.info("c2 markDeletePosition: {}, lastPosition: {}", c2.getMarkDeletedPosition(), lastPosition);
-        long lastPositionLedgerId = lastPosition.get().getLedgerId();
-        Awaitility.await().untilAsserted(() -> assertTrue(
-                c2.getMarkDeletedPosition().equals(PositionFactory.create(lastPositionLedgerId + 1, -1))
-                        || c2.getMarkDeletedPosition().equals(PositionFactory.create(lastPositionLedgerId + 2, -1))));
+        Awaitility.await()
+                .untilAsserted(() -> assertTrue(c2.getMarkDeletedPosition().compareTo(lastPosition.get()) > 0));
     }
 
     @Test(timeOut = 20000)

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger.impl;
 
 import static org.apache.bookkeeper.mledger.impl.EntryCountEstimator.estimateEntryCountByBytesSize;
 import static org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl.BOOKKEEPER_READ_OVERHEAD_PER_ENTRY;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
@@ -1284,7 +1285,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         assertEquals(c1.getMarkDeletedPosition(), p1);
         ManagedCursor finalC2 = c2;
-        Awaitility.await().untilAsserted(() -> assertTrue(finalC2.getMarkDeletedPosition().compareTo(p2) > 0));
+        Awaitility.await().untilAsserted(() -> assertThat(finalC2.getMarkDeletedPosition()).isGreaterThan(p2));
     }
 
     @Test(timeOut = 20000)
@@ -1417,8 +1418,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         //    move markDeletePosition to (lastPositionLegderId+3:-1)
         // See PR https://github.com/apache/pulsar/pull/25087.
         log.info("c2 markDeletePosition: {}, lastPosition: {}", c2.getMarkDeletedPosition(), lastPosition);
-        Awaitility.await()
-                .untilAsserted(() -> assertTrue(c2.getMarkDeletedPosition().compareTo(lastPosition.get()) >= 0));
+        Awaitility.await().untilAsserted(
+                () -> assertThat(c2.getMarkDeletedPosition()).isGreaterThanOrEqualTo(lastPosition.get()));
     }
 
     @Test(timeOut = 20000)
@@ -1505,7 +1506,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // To make sure ManagedLedgerImpl.maybeUpdateCursorBeforeTrimmingConsumedLedger() is completed, we should
         // wait until c2.getMarkDeletedPosition() equals 15:-1, see PR https://github.com/apache/pulsar/pull/25087.
         Awaitility.await()
-                .untilAsserted(() -> assertTrue(c2.getMarkDeletedPosition().compareTo(lastPosition.get()) > 0));
+                .untilAsserted(() -> assertThat(c2.getMarkDeletedPosition()).isGreaterThan(lastPosition.get()));
     }
 
     @Test(timeOut = 20000)
@@ -1556,7 +1557,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // See PR https://github.com/apache/pulsar/pull/25087.
         log.info("c2 markDeletePosition: {}, lastPosition: {}", c2.getMarkDeletedPosition(), lastPosition);
         Awaitility.await()
-                .untilAsserted(() -> assertTrue(c2.getMarkDeletedPosition().compareTo(lastPosition.get()) > 0));
+                .untilAsserted(() -> assertThat(c2.getMarkDeletedPosition()).isGreaterThan(lastPosition.get()));
     }
 
     @Test(timeOut = 20000)

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -583,7 +583,10 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         @Cleanup("shutdown")
         ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
-        ledger = factory2.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(1));
+        // Add retry logic here to prove open operation will finally success despite race condition.
+        ledger = ManagedLedgerTestUtil.retry(
+                () -> factory2.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(1)));
+
 
         c1 = ledger.openCursor("c1");
         c2 = ledger.openCursor("c2");

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -1398,9 +1398,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         // Reopen
         @Cleanup("shutdown") ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
-        // flaky test case: may throw MetadataStoreException$BadVersionException, race condition:
-        // 1. my_test_ledger ledger rollover triggers async cursor.asyncMarkDelete() operation.
-        // 2. factory2.open() triggers recovery, read versionA ManagedLedgerInfo of my_test_ledger ledger.
+        // flaky test case: factory2.open() may throw MetadataStoreException$BadVersionException, race condition:
+        // 1. my_test_ledger ledger rollover triggers cursor.asyncMarkDelete() operation.
+        // 2. factory2.open() triggers ledger recovery, read versionA ManagedLedgerInfo of my_test_ledger ledger.
         // 3. cursor.asyncMarkDelete() triggers MetaStoreImpl.asyncUpdateLedgerIds(), update versionB ManagedLedgerInfo
         //    into metaStore.
         // 4. factory2.open() triggers MetaStoreImpl.asyncUpdateLedgerIds(), update versionA ManagedLedgerInfo
@@ -1412,9 +1412,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         // Three cases:
         // 1. cursor recovered with lastPosition markDeletePosition
-        // 2. cursor recovered with (lastPositionLegderId+1:-1) markDeletePosition, cursor ledger not rolled over, we
+        // 2. cursor recovered with (lastPositionLedgerId+1:-1) markDeletePosition, cursor ledger not rolled over, we
         //    move markDeletePosition to (lastPositionLegderId+2:-1)
-        // 3. cursor recovered with (lastPositionLegderId+1:-1) markDeletePosition, cursor ledger rolled over, we
+        // 3. cursor recovered with (lastPositionLedgerId+1:-1) markDeletePosition, cursor ledger rolled over, we
         //    move markDeletePosition to (lastPositionLegderId+3:-1)
         // See PR https://github.com/apache/pulsar/pull/25087.
         log.info("c2 markDeletePosition: {}, lastPosition: {}", c2.getMarkDeletedPosition(), lastPosition);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -1553,7 +1553,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // flaky test case: c2.getMarkDeletedPosition() may be equals lastPositionLedgerId+1 or lastPositionLedgerId+2,
         // the last c1.asyncMarkDelete() operation may trigger a cursor ledger rollover
         // See PR https://github.com/apache/pulsar/pull/25087.
-        log.info("c2 markDeletePosition: {}, lastPosition: {}", c2.getMarkDeletedPosition(), lastPosition);
         Awaitility.await()
                 .untilAsserted(() -> assertThat(c2.getMarkDeletedPosition()).isGreaterThan(lastPosition.get()));
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -1285,7 +1285,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c1.getMarkDeletedPosition(), p1);
         ManagedCursor finalC2 = c2;
         Awaitility.await()
-                .untilAsserted(() -> assertEquals(finalC2.getMarkDeletedPosition(), new ImmutablePositionImpl(6, -1)));
+                .untilAsserted(() -> assertEquals(finalC2.getMarkDeletedPosition(), PositionFactory.create(6, -1)));
     }
 
     @Test(timeOut = 20000)
@@ -1422,8 +1422,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         Awaitility.await().untilAsserted(() ->
                 assertTrue(
                         c2.getMarkDeletedPosition().equals(lastPosition.get())
-                        || c2.getMarkDeletedPosition().equals(new ImmutablePositionImpl(lastPositionLedgerId + 2, -1))
-                        || c2.getMarkDeletedPosition().equals(new ImmutablePositionImpl(lastPositionLedgerId + 3, -1))
+                        || c2.getMarkDeletedPosition().equals(PositionFactory.create(lastPositionLedgerId + 2, -1))
+                        || c2.getMarkDeletedPosition().equals(PositionFactory.create(lastPositionLedgerId + 3, -1))
                 )
         );
     }
@@ -1464,7 +1464,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
             }, null);
         }
         addEntryLatch.await();
-        assertEquals(lastPosition.get(), new ImmutablePositionImpl(13, 0));
+        assertEquals(lastPosition.get(), PositionFactory.create(13, 0));
 
         // If we set num=100, to avoid flaky test, we should add Thread.sleep(1000) here to make sure ledger rollover
         // is finished, but this sleep can not guarantee c1 always recovered with markDeletePosition 12:9.
@@ -1513,7 +1513,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // To make sure ManagedLedgerImpl.maybeUpdateCursorBeforeTrimmingConsumedLedger() is completed, we should
         // wait until c2.getMarkDeletedPosition() equals 15:-1, see PR https://github.com/apache/pulsar/pull/25087.
         Awaitility.await()
-                .untilAsserted(() -> assertEquals(c2.getMarkDeletedPosition(), new ImmutablePositionImpl(15, -1)));
+                .untilAsserted(() -> assertEquals(c2.getMarkDeletedPosition(), PositionFactory.create(15, -1)));
     }
 
     @Test(timeOut = 20000)
@@ -1565,9 +1565,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         log.info("c2 markDeletePosition: {}, lastPosition: {}", c2.getMarkDeletedPosition(), lastPosition);
         long lastPositionLedgerId = lastPosition.get().getLedgerId();
         Awaitility.await().untilAsserted(() -> assertTrue(
-                c2.getMarkDeletedPosition().equals(new ImmutablePositionImpl(lastPositionLedgerId + 1, -1))
-                        || c2.getMarkDeletedPosition()
-                        .equals(new ImmutablePositionImpl(lastPositionLedgerId + 2, -1))));
+                c2.getMarkDeletedPosition().equals(PositionFactory.create(lastPositionLedgerId + 1, -1))
+                        || c2.getMarkDeletedPosition().equals(PositionFactory.create(lastPositionLedgerId + 2, -1))));
     }
 
     @Test(timeOut = 20000)

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -1399,13 +1399,11 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // Reopen
         @Cleanup("shutdown") ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         // flaky test case: factory2.open() may throw MetadataStoreException$BadVersionException, race condition:
-        // 1. my_test_ledger ledger rollover triggers cursor.asyncMarkDelete() operation.
-        // 2. factory2.open() triggers ledger recovery, read versionA ManagedLedgerInfo of my_test_ledger ledger.
-        // 3. cursor.asyncMarkDelete() triggers MetaStoreImpl.asyncUpdateLedgerIds(), update versionB ManagedLedgerInfo
-        //    into metaStore.
-        // 4. factory2.open() triggers MetaStoreImpl.asyncUpdateLedgerIds(), update versionA ManagedLedgerInfo
+        // 1. factory2.open() triggers ledger recovery, read versionA ManagedLedgerInfo of my_test_ledger ledger.
+        // 2. my_test_ledger ledger rollover triggers MetaStoreImpl.asyncUpdateLedgerIds(), update versionB
+        //    ManagedLedgerInfo into metaStore.
+        // 3. factory2.open() triggers MetaStoreImpl.asyncUpdateLedgerIds(), update versionA ManagedLedgerInfo
         //    into metaStore, then throws BadVersionException and moves my_test_ledger ledger to fenced state.
-        // See PR https://github.com/apache/pulsar/pull/25087.
         // Recovery open async_mark_delete_blocking_test_ledger ledger, ledgerId++
         ledger = factory2.open("my_test_ledger");
         ManagedCursor c2 = ledger.openCursor("c1");

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/util/ManagedLedgerTestUtil.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/util/ManagedLedgerTestUtil.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class ManagedLedgerTestUtil {
+
+    public static <T> T retry(ThrowingSupplier<T> supplier) {
+        return retry(10, supplier);
+    }
+
+    public static <T> T retry(int retryCount, ThrowingSupplier<T> supplier) {
+        for (int i = 0; i < retryCount; i++) {
+            if (i > 0) {
+                try {
+                    log.info("Retrying after 100ms {}/{}", i, retryCount);
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            try {
+                return supplier.get();
+            } catch (Exception e) {
+                log.warn("Failed to execute supplier: {}", supplier, e);
+            }
+        }
+        throw new RuntimeException("Failed to execute supplier after " + retryCount  + " retries");
+    }
+
+    @FunctionalInterface
+    public interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/25092

### Motivation

`ManagedCursorTest.asyncMarkDeleteBlocking()` test is very flaky after PR https://github.com/apache/pulsar/pull/25087, so fix it.

### Modifications

1. When doing local debug, I see many logs like this:

```
org.apache.bookkeeper.mledger.ManagedLedgerException: org.apache.bookkeeper.mledger.impl.ManagedCursorImpl$MarkDeletingMarkedPosition: Mark deleting an already mark-deleted position. Current mark-delete: 13:9 -- attempted mark delete: 13:8
Caused by: org.apache.bookkeeper.mledger.impl.ManagedCursorImpl$MarkDeletingMarkedPosition: Mark deleting an already mark-deleted position. Current mark-delete: 13:9 -- attempted mark delete: 13:8
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.setAcknowledgedPosition(ManagedCursorImpl.java:2076)
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncMarkDelete(ManagedCursorImpl.java:2212)
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.maybeUpdateCursorBeforeTrimmingConsumedLedger(ManagedLedgerImpl.java:2736)
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl$14.operationComplete(ManagedLedgerImpl.java:1768)
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl$14.operationComplete(ManagedLedgerImpl.java:1747)
	at org.apache.bookkeeper.mledger.impl.MetaStoreImpl.lambda$asyncUpdateLedgerIds$7(MetaStoreImpl.java:187)
```

So I modify `if (!lastAckedPosition.equals(cursor.getMarkDeletedPosition()))` to `if (lastAckedPosition.compareTo(cursor.getMarkDeletedPosition()) > 0)` in `ManagedLedgerImpl`.

2. Modify some typos, and add some todos(could be deleted if not needed) in `ManagedLedgerImpl`.

3. Fix `asyncMarkDeleteBlocking()` flaky test, see method comments.

4. Add `asyncMarkDeleteBlockingWithOneShot()` test, see method comments. I move `c1.asyncMarkDelete` out of `asyncAddEntry#addComplete` callback method, because the two operations seem to compete for the same ledgerId, which is the reason why make `asyncMarkDeleteBlocking()` test is more flaky after https://github.com/apache/pulsar/pull/25087. Some logs in previous `asyncMarkDeleteBlocking()` unfixed flaky test.

```
2025-12-19T21:58:48,996 - INFO  - [main:ManagedCursorTest@1405] - size: 100, positions: [3:0, 3:1, 3:2, 3:3, 3:4, 3:5, 3:6, 3:7, 3:8, 3:9, 5:0, 5:1, 5:2, 5:3, 5:4, 5:5, 5:6, 5:7, 5:8, 5:9, 7:0, 7:1, 7:2, 7:3, 7:4, 7:5, 7:6, 7:7, 7:8, 7:9, 9:0, 9:1, 9:2, 9:3, 9:4, 9:5, 9:6, 9:7, 9:8, 9:9, 11:0, 11:1, 11:2, 11:3, 11:4, 11:5, 11:6, 11:7, 11:8, 11:9, 13:0, 13:1, 13:2, 13:3, 13:4, 13:5, 13:6, 13:7, 13:8, 13:9, 14:0, 14:1, 14:2, 14:3, 14:4, 14:5, 14:6, 14:7, 14:8, 14:9, 16:0, 16:1, 16:2, 16:3, 16:4, 16:5, 16:6, 16:7, 16:8, 16:9, 18:0, 18:1, 18:2, 18:3, 18:4, 18:5, 18:6, 18:7, 18:8, 18:9, 19:0, 19:1, 19:2, 19:3, 19:4, 19:5, 19:6, 19:7, 19:8, 19:9]

2025-12-19T21:58:48,625 - INFO  - [main:ManagedCursorTest@1405] - size: 100, positions: [3:0, 3:1, 3:2, 3:3, 3:4, 3:5, 3:6, 3:7, 3:8, 3:9, 5:0, 5:1, 5:2, 5:3, 5:4, 5:5, 5:6, 5:7, 5:8, 5:9, 7:0, 7:1, 7:2, 7:3, 7:4, 7:5, 7:6, 7:7, 7:8, 7:9, 8:0, 8:1, 8:2, 8:3, 8:4, 8:5, 8:6, 8:7, 8:8, 8:9, 10:0, 10:1, 10:2, 10:3, 10:4, 10:5, 10:6, 10:7, 10:8, 10:9, 11:0, 11:1, 11:2, 11:3, 11:4, 11:5, 11:6, 11:7, 11:8, 11:9, 13:0, 13:1, 13:2, 13:3, 13:4, 13:5, 13:6, 13:7, 13:8, 13:9, 15:0, 15:1, 15:2, 15:3, 15:4, 15:5, 15:6, 15:7, 15:8, 15:9, 17:0, 17:1, 17:2, 17:3, 17:4, 17:5, 17:6, 17:7, 17:8, 17:9, 19:0, 19:1, 19:2, 19:3, 19:4, 19:5, 19:6, 19:7, 19:8, 19:9]
```

5. Add `asyncMarkDeleteBlockingWithMultiShots()` test, see method comments. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
