### PR TITLE
[fix][broker] Fix markDeletedPosition race condition in ManagedLedgerImpl.maybeUpdateCursorBeforeTrimmingConsumedLedger() method

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1250,16 +1250,17 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public long getNumberOfEntries() {
+        Position readPos = readPosition;
         Position lastPosition = ledger.getLastPosition();
         Position nextPosition = lastPosition.getNext();
-        if (readPosition.compareTo(nextPosition) > 0) {
+        if (readPos.compareTo(nextPosition) > 0) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Read position {} is ahead of last position {}. There are no entries to read",
-                        ledger.getName(), name, readPosition, lastPosition);
+                        ledger.getName(), name, readPos, lastPosition);
             }
             return 0;
         } else {
-            return getNumberOfEntries(Range.closedOpen(readPosition, nextPosition));
+            return getNumberOfEntries(Range.closedOpen(readPos, nextPosition));
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1250,14 +1250,16 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public long getNumberOfEntries() {
-        if (readPosition.compareTo(ledger.getLastPosition().getNext()) > 0) {
+        Position lastPosition = ledger.getLastPosition();
+        Position nextPosition = lastPosition.getNext();
+        if (readPosition.compareTo(nextPosition) > 0) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Read position {} is ahead of last position {}. There are no entries to read",
-                        ledger.getName(), name, readPosition, ledger.getLastPosition());
+                        ledger.getName(), name, readPosition, lastPosition);
             }
             return 0;
         } else {
-            return getNumberOfEntries(Range.closedOpen(readPosition, ledger.getLastPosition().getNext()));
+            return getNumberOfEntries(Range.closedOpen(readPosition, nextPosition));
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -483,15 +483,20 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                                 pendingInitializeLedgers.remove(name, pendingLedger);
                                 future.complete(newledger);
 
-                                // May need to update the cursor position and wait them finished
-                                newledger.maybeUpdateCursorBeforeTrimmingConsumedLedger().whenComplete((__, ex) -> {
-                                    // ignore ex since it is handled in maybeUpdateCursorBeforeTrimmingConsumedLedger
-                                    future.complete(newledger);
-                                    // May need to trigger offloading
-                                    if (config.isTriggerOffloadOnTopicLoad()) {
-                                        newledger.maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
-                                    }
-                                });
+                                newledger.maybeUpdateCursorBeforeTrimmingConsumedLedger();
+                                if (config.isTriggerOffloadOnTopicLoad()) {
+                                    newledger.maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
+                                }
+
+//                                // May need to update the cursor position and wait them finished
+//                                newledger.maybeUpdateCursorBeforeTrimmingConsumedLedger().whenComplete((__, ex) -> {
+//                                    // ignore ex since it is handled in maybeUpdateCursorBeforeTrimmingConsumedLedger
+//                                    future.complete(newledger);
+//                                    // May need to trigger offloading
+//                                    if (config.isTriggerOffloadOnTopicLoad()) {
+//                                        newledger.maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
+//                                    }
+//                                });
                             }
 
                             @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -481,22 +481,15 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                             public void initializeComplete() {
                                 log.info("[{}] Successfully initialize managed ledger", name);
                                 pendingInitializeLedgers.remove(name, pendingLedger);
-                                future.complete(newledger);
-
-                                newledger.maybeUpdateCursorBeforeTrimmingConsumedLedger();
-                                if (config.isTriggerOffloadOnTopicLoad()) {
-                                    newledger.maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
-                                }
-
-//                                // May need to update the cursor position and wait them finished
-//                                newledger.maybeUpdateCursorBeforeTrimmingConsumedLedger().whenComplete((__, ex) -> {
-//                                    // ignore ex since it is handled in maybeUpdateCursorBeforeTrimmingConsumedLedger
-//                                    future.complete(newledger);
-//                                    // May need to trigger offloading
-//                                    if (config.isTriggerOffloadOnTopicLoad()) {
-//                                        newledger.maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
-//                                    }
-//                                });
+                                // May need to update the cursor position and wait them finished
+                                newledger.maybeUpdateCursorBeforeTrimmingConsumedLedger().whenComplete((__, ex) -> {
+                                    // ignore ex since it is handled in maybeUpdateCursorBeforeTrimmingConsumedLedger
+                                    future.complete(newledger);
+                                    // May need to trigger offloading
+                                    if (config.isTriggerOffloadOnTopicLoad()) {
+                                        newledger.maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
+                                    }
+                                });
                             }
 
                             @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -483,12 +483,15 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                                 pendingInitializeLedgers.remove(name, pendingLedger);
                                 future.complete(newledger);
 
-                                // May need to update the cursor position
-                                newledger.maybeUpdateCursorBeforeTrimmingConsumedLedger();
-                                // May need to trigger offloading
-                                if (config.isTriggerOffloadOnTopicLoad()) {
-                                    newledger.maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
-                                }
+                                // May need to update the cursor position and wait them finished
+                                newledger.maybeUpdateCursorBeforeTrimmingConsumedLedger().whenComplete((__, ex) -> {
+                                    // ignore ex since it is handled in maybeUpdateCursorBeforeTrimmingConsumedLedger
+                                    future.complete(newledger);
+                                    // May need to trigger offloading
+                                    if (config.isTriggerOffloadOnTopicLoad()) {
+                                        newledger.maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
+                                    }
+                                });
                             }
 
                             @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2734,11 +2734,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 }
             } else {
                 // TODO curPointedLedger==null, should we move cursor mark deleted position to nextPointedLedger:-1?
-                // Sample case: Opening an empty ledger with ledgers:(ledgerId:-1) will cause curPointedLedger==null,
-                // then recovery read will create a new ledger: (ledgerId+1:-1).
-                // If old markDeletePosition==(ledgerId:-1), I think we should move it to (ledgerId+1:-1),
-                // or it will casue cursor position and ledger inconsistency.
-                // See PR https://github.com/apache/pulsar/pull/25087
+                // Sample case: Opening an empty ledger with ledgers:(ledgerId:-1), if cursor position is
+                // (ledgerId-1:entryNum-1) and old ledger is trimmed, then curPointedLedger wil be null.
+                // I think we should move cursor position to (ledgerId:-1), or it will cause cursor position and ledger
+                // inconsistency. See PR https://github.com/apache/pulsar/pull/25087
                 log.warn("Cursor: {} does not exist in the managed-ledger.", cursor);
             }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2715,11 +2715,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             cursorMarkDeleteFutures.add(future);
 
             // Snapshot positions into a local variables to avoid race condition.
-            Position persistentMarkDeletedPosition = cursor.getPersistentMarkDeletedPosition();
             Position markDeletedPosition = cursor.getMarkDeletedPosition();
-            Position lastAckedPosition =
-                    persistentMarkDeletedPosition != null ? persistentMarkDeletedPosition : markDeletedPosition;
-//            Position lastAckedPosition = markDeletedPosition;
+            Position lastAckedPosition = markDeletedPosition;
             LedgerInfo curPointedLedger   = ledgers.get(lastAckedPosition.getLedgerId());
             LedgerInfo nextPointedLedger = Optional.ofNullable(ledgers.higherEntry(lastAckedPosition.getLedgerId()))
                     .map(Map.Entry::getValue).orElse(null);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2739,22 +2739,20 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 Position finalPosition = lastAckedPosition;
                 log.info("Mark deleting cursor:{} from {} to {} since ledger consumed completely.", cursor,
                         markDeletedPosition, lastAckedPosition);
-                cursor.asyncMarkDelete(lastAckedPosition, cursor.getProperties(),
-                    new MarkDeleteCallback() {
-                        @Override
-                        public void markDeleteComplete(Object ctx) {
-                            log.info("Successfully persisted cursor position for cursor:{} to {}",
-                                    cursor, finalPosition);
-                            future.complete(null);
-                        }
+                cursor.asyncMarkDelete(lastAckedPosition, null, new MarkDeleteCallback() {
+                    @Override
+                    public void markDeleteComplete(Object ctx) {
+                        log.info("Successfully persisted cursor position for cursor:{} to {}", cursor, finalPosition);
+                        future.complete(null);
+                    }
 
-                        @Override
-                        public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
-                            log.warn("Failed to mark delete: {} from {} to {}. ", cursor,
-                                    cursor.getMarkDeletedPosition(), finalPosition, exception);
-                            future.completeExceptionally(exception);
-                        }
-                    }, null);
+                    @Override
+                    public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
+                        log.warn("Failed to mark delete: {} from {} to {}. ", cursor, cursor.getMarkDeletedPosition(),
+                                finalPosition, exception);
+                        future.completeExceptionally(exception);
+                    }
+                }, null);
             } else if (compareResult == 0) {
                 log.debug("No need to reset cursor: {}, last acked position equals to current mark-delete position {}.",
                         cursor, markDeletedPosition);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2716,7 +2716,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             cursorMarkDeleteFutures.add(future);
 
             // Snapshot cursor.getMarkDeletedPosition() into a local variable to avoid race condition.
-            Position markDeletedPosition = PositionFactory.create(cursor.getMarkDeletedPosition());
+            Position markDeletedPosition = cursor.getMarkDeletedPosition();
             Position lastAckedPosition = cursor.getPersistentMarkDeletedPosition() != null
                     ? cursor.getPersistentMarkDeletedPosition() : markDeletedPosition;
             LedgerInfo curPointedLedger   = ledgers.get(lastAckedPosition.getLedgerId());
@@ -2770,10 +2770,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 // Should not happen
                 log.warn("Trying to mark delete an already mark-deleted position. Current mark-delete:"
                         + " {} -- attempted position: {}", markDeletedPosition, lastAckedPosition);
-                future.completeExceptionally(new ManagedLedgerException(
-                        "Trying to mark delete an already mark-deleted position when update cursor. Current "
-                                + "mark-delete: " + markDeletedPosition + " -- attempted mark delete: "
-                                + lastAckedPosition));
+                future.completeExceptionally(null);
+//                future.completeExceptionally(new ManagedLedgerException(
+//                        "Trying to mark delete an already mark-deleted position when update cursor. Current "
+//                                + "mark-delete: " + markDeletedPosition + " -- attempted mark delete: "
+//                                + lastAckedPosition));
             }
         }
         return FutureUtil.waitForAll(cursorMarkDeleteFutures);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2763,8 +2763,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                         cursor, markDeletedPosition);
                 future.complete(null);
             } else {
-                // May happen, persistentMarkDeletedPosition is updated after markDeletedPosition
-                log.info("Ledger rollover tries to mark delete an already mark-deleted position. Current mark-delete:"
+                // Should not happen
+                log.warn("Ledger rollover tries to mark delete an already mark-deleted position. Current mark-delete:"
                         + " {} -- attempted position: {}", markDeletedPosition, lastAckedPosition);
                 future.complete(null);
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2756,7 +2756,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                     cursor.getMarkDeletedPosition(), finalPosition, exception);
                         }
                     }, null);
-            } else if (compareResult < 0) {
+            } else if (compareResult == 0) {
+                log.debug("No need to reset cursor: {}, last acked position equals to current mark-delete position {}.",
+                        cursor, markDeletedPosition);
+            } else {
                 // Should not happen
                 log.warn("Trying to mark delete cursor to an already mark-deleted position. Current mark-delete:"
                         + " {} -- attempted position: {}", markDeletedPosition, lastAckedPosition);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2711,28 +2711,37 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     public void maybeUpdateCursorBeforeTrimmingConsumedLedger() {
         for (ManagedCursor cursor : cursors) {
+            // Snapshot cursor.getMarkDeletedPosition() into a local variable to avoid race condition.
+            Position markDeletedPosition = PositionFactory.create(cursor.getMarkDeletedPosition());
             Position lastAckedPosition = cursor.getPersistentMarkDeletedPosition() != null
-                    ? cursor.getPersistentMarkDeletedPosition() : cursor.getMarkDeletedPosition();
-            LedgerInfo currPointedLedger = ledgers.get(lastAckedPosition.getLedgerId());
+                    ? cursor.getPersistentMarkDeletedPosition() : markDeletedPosition;
+            LedgerInfo curPointedLedger   = ledgers.get(lastAckedPosition.getLedgerId());
             LedgerInfo nextPointedLedger = Optional.ofNullable(ledgers.higherEntry(lastAckedPosition.getLedgerId()))
                     .map(Map.Entry::getValue).orElse(null);
 
-            if (currPointedLedger != null) {
+            if (curPointedLedger != null) {
                 if (nextPointedLedger != null) {
                     if (lastAckedPosition.getEntryId() != -1
-                            && lastAckedPosition.getEntryId() + 1 >= currPointedLedger.getEntries()) {
+                            && lastAckedPosition.getEntryId() + 1 >= curPointedLedger.getEntries()) {
                         lastAckedPosition = PositionFactory.create(nextPointedLedger.getLedgerId(), -1);
                     }
                 } else {
                     log.debug("No need to reset cursor: {}, current ledger is the last ledger.", cursor);
                 }
             } else {
+                // TODO curPointedLedger==null, should we move cursor mark deleted position to nextPointedLedger:-1?
+                // Sample case: Opening an empty ledger with ledgers:(ledgerId:-1) will cause curPointedLedger==null,
+                // then recovery read will create a new ledger: (ledgerId+1:-1).
+                // If old markDeletePosition==(ledgerId:-1), I think we should move it to (ledgerId+1:-1),
+                // or it will casue cursor position and ledger inconsistency.
+                // See PR https://github.com/apache/pulsar/pull/25087
                 log.warn("Cursor: {} does not exist in the managed-ledger.", cursor);
             }
 
-            if (!lastAckedPosition.equals(cursor.getMarkDeletedPosition())) {
+            int compareResult = lastAckedPosition.compareTo(markDeletedPosition);
+            if (compareResult > 0) {
                 Position finalPosition = lastAckedPosition;
-                log.info("Reset cursor:{} to {} since ledger consumed completely", cursor, lastAckedPosition);
+                log.info("Mark delete cursor:{} to {} since ledger consumed completely", cursor, lastAckedPosition);
                 cursor.asyncMarkDelete(lastAckedPosition, cursor.getProperties(),
                     new MarkDeleteCallback() {
                         @Override
@@ -2743,10 +2752,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
                         @Override
                         public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
-                            log.warn("Failed to reset cursor: {} from {} to {}. Trimming thread will retry next time.",
-                                    cursor, cursor.getMarkDeletedPosition(), finalPosition, exception);
+                            log.warn("Failed to mark delete cursor: {} from {} to {}. ", cursor,
+                                    cursor.getMarkDeletedPosition(), finalPosition, exception);
                         }
                     }, null);
+            } else if (compareResult < 0) {
+                // Should not happen
+                log.warn("Trying to mark delete cursor to an already mark-deleted position. Current mark-delete:"
+                        + " {} -- attempted position: {}", markDeletedPosition, lastAckedPosition);
             }
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
@@ -103,11 +103,13 @@ public class NonDurableCursorImpl extends ManagedCursorImpl {
     protected void internalAsyncMarkDelete(final Position newPosition, Map<String, Long> properties,
             final MarkDeleteCallback callback, final Object ctx, Runnable alignAcknowledgeStatusAfterPersisted) {
         // Bypass persistence of mark-delete position and individually deleted messages info
-
-        MarkDeleteEntry mdEntry = new MarkDeleteEntry(newPosition, properties, callback, ctx,
-                alignAcknowledgeStatusAfterPersisted);
+        MarkDeleteEntry mdEntry;
         lock.writeLock().lock();
         try {
+            // use given properties or when missing, use the properties from the previous field value
+            Map<String, Long> propertiesToUse = properties != null ? properties : getProperties();
+            mdEntry = new MarkDeleteEntry(newPosition, propertiesToUse, callback, ctx,
+                    alignAcknowledgeStatusAfterPersisted);
             lastMarkDeleteEntry = mdEntry;
             mdEntry.alignAcknowledgeStatus();
         } finally {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4441,7 +4441,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                     ManagedLedger ledger2 = factory2.open("testFlushCursorAfterInactivity", config);
                     ManagedCursor c2 = ledger2.openCursor("c");
 
-                    assertEquals(c2.getMarkDeletedPosition(), positions.get(positions.size() - 1));
+                    assertThat(c2.getMarkDeletedPosition()).isGreaterThan(positions.get(positions.size() - 1));
                 });
     }
 
@@ -4500,7 +4500,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                     ManagedLedger ledger2 = factory2.open("testFlushCursorAfterIndDelInactivity", config);
                     ManagedCursor c2 = ledger2.openCursor("c");
 
-                    assertEquals(c2.getMarkDeletedPosition(), positions.get(positions.size() - 1));
+                    assertThat(c2.getMarkDeletedPosition()).isGreaterThan(positions.get(positions.size() - 1));
                 });
     }
 
@@ -4551,6 +4551,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                     ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
                     ManagedLedger ledger2 = factory2.open("testFlushCursorAfterInactivity", config);
                     ManagedCursor c2 = ledger2.openCursor("c");
+
                     assertThat(c2.getMarkDeletedPosition()).isGreaterThan(positions.get(positions.size() - 1));
                 });
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4506,7 +4506,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
 
 
-    @Test
+    @Test(invocationCount = 100)
     public void testFlushCursorAfterError() throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setThrottleMarkDelete(1.0);
@@ -4551,8 +4551,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                     ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
                     ManagedLedger ledger2 = factory2.open("testFlushCursorAfterInactivity", config);
                     ManagedCursor c2 = ledger2.openCursor("c");
-
-                    assertEquals(c2.getMarkDeletedPosition(), positions.get(positions.size() - 1));
+                    assertThat(c2.getMarkDeletedPosition()).isGreaterThan(positions.get(positions.size() - 1));
                 });
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -508,7 +508,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedCursorImpl cursorRecovered = (ManagedCursorImpl) ml.openCursor(cursorName);
         assertThat(cursorRecovered.getPersistentMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
         // If previous ledger is trimmed, Cursor: ManagedCursorImpl{ledger=ml_test, name=c1, ackPos=12:0, readPos=15:0}
-        // does not exist in the managed-ledger.
+        // does not exist in the managed-ledger. Recovered cursor's position will not be moved forward.
         // TODO should be handled in ledger trim process.
         assertThat(cursorRecovered.getMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
 
@@ -4822,7 +4822,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
-    public void testLazyCursorLedgerCreation() throws Exception {
+    public void testEagerCursorLedgerCreation() throws Exception {
         ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory
                 .open("testLazyCursorLedgerCreation", managedLedgerConfig);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4840,8 +4840,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ledger = (ManagedLedgerImpl) factory
                 .open("testLazyCursorLedgerCreation", managedLedgerConfig);
         ManagedCursorImpl cursor1 = (ManagedCursorImpl) ledger.openCursor("test");
-        assertEquals(cursor1.getState(), "NoLedger");
-        assertEquals(cursor1.getMarkDeletedPosition(), finalLastPosition);
+        assertEquals(cursor1.getState(), "Open");
+        assertThat(cursor1.getMarkDeletedPosition()).isGreaterThan(finalLastPosition);
 
         // Verify the recovered cursor can work with new mark delete.
         lastPosition = null;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4506,7 +4506,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
 
 
-    @Test(invocationCount = 100)
+    @Test
     public void testFlushCursorAfterError() throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setThrottleMarkDelete(1.0);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -407,7 +407,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ml.close();
         ml = (ManagedLedgerImpl) factory.open(mlName, mlConfig);
         ManagedCursorImpl cursorRecovered = (ManagedCursorImpl) ml.openCursor(cursorName);
-        assertEquals(cursorRecovered.getPersistentMarkDeletedPosition(), lastEntry);
+        assertThat(cursorRecovered.getPersistentMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
+        assertThat(cursorRecovered.getMarkDeletedPosition()).isGreaterThan(lastEntry);
 
         // cleanup.
         ml.delete();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -499,12 +499,18 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertTrue(slowestReadPosition.getLedgerId() >= lastEntry.getLedgerId());
         assertTrue(slowestReadPosition.getEntryId() >= lastEntry.getEntryId());
         assertEquals(cursor.getPersistentMarkDeletedPosition(), lastEntry);
+        assertThat(cursor.getPersistentMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
+        assertThat(cursor.getMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
 
         // Verify the mark delete position can be recovered properly.
         ml.close();
         ml = (ManagedLedgerImpl) factory.open(mlName, mlConfig);
         ManagedCursorImpl cursorRecovered = (ManagedCursorImpl) ml.openCursor(cursorName);
-        assertEquals(cursorRecovered.getPersistentMarkDeletedPosition(), lastEntry);
+        assertThat(cursorRecovered.getPersistentMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
+        // If previous ledger is trimmed, Cursor: ManagedCursorImpl{ledger=ml_test, name=c1, ackPos=12:0, readPos=15:0}
+        // does not exist in the managed-ledger.
+        // TODO should be handled in ledger trim process.
+        assertThat(cursorRecovered.getMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
 
         // cleanup.
         ml.delete();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3786,8 +3786,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         });
     }
 
-    // Huh, maybeUpdateCursorBeforeTrimmingConsumedLedger seems not working well.
-    @Test(timeOut = 20000)
+    @Test(timeOut = 20000, invocationCount = 1000)
     public void testNeverThrowsMarkDeletingMarkedPositionInMaybeUpdateCursorBeforeTrimmingConsumedLedger()
             throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();
@@ -3822,6 +3821,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
                     cursor.asyncMarkDelete(position, new MarkDeleteCallback() {
                         @Override
                         public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
+                            fail("Should never fail",  exception);
                         }
 
                         @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3786,7 +3786,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         });
     }
 
-    @Test(timeOut = 20000, invocationCount = 1000)
+    @Test(timeOut = 20000)
     public void testNeverThrowsMarkDeletingMarkedPositionInMaybeUpdateCursorBeforeTrimmingConsumedLedger()
             throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -5204,7 +5204,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         latch.await();
         assertThat(cursor.getPersistentMarkDeletedPosition()).isGreaterThanOrEqualTo(lastPosition);
         assertThat(ledger.getCursors().getSlowestCursorPosition()).isGreaterThanOrEqualTo(lastPosition);
-        assertEquals(cursor.getProperties(), properties);
+        // assertEquals(cursor.getProperties(), properties);
 
         // 3. Add Entry 2. Triggers second rollover process.
         // This implicitly calls maybeUpdateCursorBeforeTrimmingConsumedLedger due to rollover
@@ -5217,6 +5217,6 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         assertEquals(cursor.getPersistentMarkDeletedPosition(), PositionFactory.create(p.getLedgerId(), -1));
 
         // Verify properties are preserved after cursor reset
-        assertEquals(cursor.getProperties(), properties);
+        // assertEquals(cursor.getProperties(), properties);
     }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3826,12 +3826,12 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
                 }
             }, null);
-            taskFireLatch.wait();
+            taskFireLatch.await();
             CompletableFuture<Void> future = managedLedger.maybeUpdateCursorBeforeTrimmingConsumedLedger();
             updateCursorFutures.add(future);
         }
 
-        latch.countDown();
+        latch.await();
         assertEquals(cursor.getNumberOfEntries(), 0);
         // Will not throw exception
         FutureUtil.waitForAll(updateCursorFutures).get();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -5204,7 +5204,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         latch.await();
         assertThat(cursor.getPersistentMarkDeletedPosition()).isGreaterThanOrEqualTo(lastPosition);
         assertThat(ledger.getCursors().getSlowestCursorPosition()).isGreaterThanOrEqualTo(lastPosition);
-        // assertEquals(cursor.getProperties(), properties);
+        assertEquals(cursor.getProperties(), properties);
 
         // 3. Add Entry 2. Triggers second rollover process.
         // This implicitly calls maybeUpdateCursorBeforeTrimmingConsumedLedger due to rollover
@@ -5217,6 +5217,6 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         assertEquals(cursor.getPersistentMarkDeletedPosition(), PositionFactory.create(p.getLedgerId(), -1));
 
         // Verify properties are preserved after cursor reset
-        // assertEquals(cursor.getProperties(), properties);
+        assertEquals(cursor.getProperties(), properties);
     }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3787,7 +3787,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     }
 
     @Test(timeOut = 20000)
-    public void testNeverThrowsMarkDeletingMarkedPositionInMaybeUpdateCursorBeforeTrimmingConsumedLedger()
+    public void testNeverThrowExceptionInMaybeUpdateCursorBeforeTrimmingConsumedLedger()
             throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         initManagedLedgerConfig(config);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -5286,7 +5286,8 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         config.setRetentionSizeInMB(0);
 
         ManagedLedgerImpl ledger =
-                (ManagedLedgerImpl) factory.open("testTrimmerRaceConditionWithThrottleMarkDeleteInDurableCursor", config);
+                (ManagedLedgerImpl) factory.open("testTrimmerRaceConditionWithThrottleMarkDeleteInDurableCursor",
+                        config);
         ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
 
         CountDownLatch latch = new CountDownLatch(1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -995,10 +995,9 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         // compact the topic again
         compact(topic);
 
-        // shouldn't have opened first ledger (already compacted), penultimate would have some uncompacted data.
-        // last ledger already open for writing
+        // shouldn't have opened first and penultimate ledger (already compacted), last ledger already open for writing
         assertFalse(ledgersOpened.contains(info.ledgers.get(0).ledgerId));
-        assertTrue(ledgersOpened.contains(info.ledgers.get(1).ledgerId));
+        assertFalse(ledgersOpened.contains(info.ledgers.get(1).ledgerId));
         assertFalse(ledgersOpened.contains(info.ledgers.get(2).ledgerId));
 
         // all three messages should be there when we read compacted

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -995,9 +995,10 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         // compact the topic again
         compact(topic);
 
-        // shouldn't have opened first and penultimate ledger (already compacted), last ledger already open for writing
+        // shouldn't have opened first ledger (already compacted), penultimate would have some uncompacted data.
+        // last ledger already open for writing
         assertFalse(ledgersOpened.contains(info.ledgers.get(0).ledgerId));
-        assertFalse(ledgersOpened.contains(info.ledgers.get(1).ledgerId));
+        assertTrue(ledgersOpened.contains(info.ledgers.get(1).ledgerId));
         assertFalse(ledgersOpened.contains(info.ledgers.get(2).ledgerId));
 
         // all three messages should be there when we read compacted


### PR DESCRIPTION
### Motivation

We do mark deleting operations in `ManagedLedgerImpl.maybeUpdateCursorBeforeTrimmingConsumedLedger()` after https://github.com/apache/pulsar/pull/25087.

Mark deleting an already mark-deleted position will throw an Exception.

Please see comment for race condition case: https://github.com/apache/pulsar/pull/25101#discussion_r2639087166.

See also: 
1. https://github.com/apache/pulsar/pull/25101
2. https://github.com/apache/pulsar/pull/25101#discussion_r2639019381

### Modifications

1. Modify `ManagedLedgerImpl.maybeUpdateCursorBeforeTrimmingConsumedLedger()` method:
  a. snapshot positions into a local variable to avoid race condition.
  b. use `markDeletePosition` instead of `persistentMarkDeletedPosition` to set `lastAckedPosition`, because `persistentMarkDeletedPosition` if updated after `markDeletePosition`.
  c. add if check logic to avoid mark deleting an already mark-deleted position.
  d. wait `maybeUpdateCursorBeforeTrimmingConsumedLedger()` completed when opening ledger.
  e. move `maybeUpdateCursorBeforeTrimmingConsumedLedger()` into synchronized block when creating a new ledger. I think new ledger's initialization work should be completed before the first entry is added to this ledger.

2. Modify `ManagedCursorImpl.getNumberOfEntries()` method: snapshot positions into a local variable to avoid race condition, error logs like this:

```
java.lang.IllegalArgumentException: Invalid range: [104:0..103:1)

    at com.google.common.collect.Range.<init>(Range.java:334)
    at com.google.common.collect.Range.create(Range.java:134)
    at com.google.common.collect.Range.closedOpen(Range.java:171)
    at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.getNumberOfEntries(ManagedCursorImpl.java:1253)
    at org.apache.bookkeeper.mledger.impl.ManagedLedgerTest.testNeverThrowsMarkDeletingMarkedPositionInMaybeUpdateCursorBeforeTrimmingConsumedLedger(ManagedLedgerTest.java:3838)
```

3. Ignore changes in `ManagedCursorImpl.asyncMarkDelete()` method, I just snapshot positions into a local variable to avoid race condition. It should be fixed by: https://github.com/oneby-wang/pulsar/pull/19.

4. Add `testNeverThrowsMarkDeletingMarkedPositionInMaybeUpdateCursorBeforeTrimmingConsumedLedger` test in `ManagedLedgerImplTest` to verify the code change.

5. Fix tests due to this PR's code change.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
