### PR TITLE
[improve][cli] Add client side looping in "pulsar-admin topics analyze-backlog" cli to avoid potential HTTP call timeout

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2190,62 +2190,76 @@ public class PulsarAdminToolTest {
                 getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(10, 0),
                         PositionFactory.create(10, 9));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(mockResult);
+
         cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName));
+
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
         verifyNoMoreInteractions(mockTopics);
 
         // Test with the messagePosition parameter.
         reset(mockTopics);
+
         int partitionIndex = TopicName.get(topic).getPartitionIndex();
         startMessageId = Optional.of(new MessageIdImpl(11, 10, partitionIndex));
         String messagePosition = "11:10";
         mockResult = getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(11, 10),
                 PositionFactory.create(11, 19));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(mockResult);
+
         cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -p " + messagePosition));
+
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
         verifyNoMoreInteractions(mockTopics);
 
-        // Test client side loop: server returns false aborted flag.
+        // Test client side loop: the loop termination condition is that server returns false aborted flag.
         reset(mockTopics);
+
         long backlogScanMaxEntries = 30;
         startMessageId = Optional.empty();
         AnalyzeSubscriptionBacklogResult firstResult =
                 getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(12, 0),
                         PositionFactory.create(12, 9));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(firstResult);
+
         Optional<MessageId> secondInvocationMsgId = Optional.of(new MessageIdImpl(12, 10, partitionIndex));
         AnalyzeSubscriptionBacklogResult abortedResult =
                 getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(12, 10),
                         PositionFactory.create(12, 19));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId)).thenReturn(
                 abortedResult);
+
         cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries));
+
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId);
         verifyNoMoreInteractions(mockTopics);
 
-        // Test client side loop: total entries exceeds backlogScanMaxEntries.
+        // Test client side loop: the loop termination condition is that total entries exceeds backlogScanMaxEntries.
         reset(mockTopics);
+
         backlogScanMaxEntries = 25;
         startMessageId = Optional.empty();
         firstResult = getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(13, 0),
                 PositionFactory.create(13, 9));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(firstResult);
+
         secondInvocationMsgId = Optional.of(new MessageIdImpl(13, 10, partitionIndex));
         AnalyzeSubscriptionBacklogResult moreResult =
                 getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(13, 10),
                         PositionFactory.create(13, 19));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId)).thenReturn(
                 moreResult);
+
         Optional<MessageId> thirdInvocationMsgId = Optional.of(new MessageIdImpl(13, 20, partitionIndex));
         AnalyzeSubscriptionBacklogResult lastResult =
                 getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(14, 0),
                         PositionFactory.create(14, 9));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId)).thenReturn(
                 lastResult);
+
         cmdTopics.run(
                 split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries + " -q"));
+
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId);
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -53,14 +52,11 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.mledger.Position;
-import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.pulsar.admin.cli.extensions.CustomCommandFactory;
 import org.apache.pulsar.admin.cli.utils.SchemaExtractor;
 import org.apache.pulsar.client.admin.Bookies;
@@ -93,7 +89,6 @@ import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
-import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
@@ -124,7 +119,6 @@ import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.protocol.schema.PostSchemaPayload;
-import org.apache.pulsar.common.stats.AnalyzeSubscriptionBacklogResult;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -2175,115 +2169,12 @@ public class PulsarAdminToolTest {
 
     }
 
-    @Test
-    public void topicsAnalyzeBacklog() throws Exception {
-        PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
-        Topics mockTopics = mock(Topics.class);
-        when(admin.topics()).thenReturn(mockTopics);
-        CmdTopics cmdTopics = new CmdTopics(() -> admin);
-
-        // Test backward compatibility.
-        String topic = "persistent://myprop/clust/ns1/ds1";
-        String subscriptionName = "sub1";
-        Optional<MessageId> startMessageId = Optional.empty();
-        AnalyzeSubscriptionBacklogResult mockResult =
-                getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(10, 0),
-                        PositionFactory.create(10, 9));
-        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(mockResult);
-
-        cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName));
-
-        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
-        verifyNoMoreInteractions(mockTopics);
-
-        // Test with the messagePosition parameter.
-        reset(mockTopics);
-
-        int partitionIndex = TopicName.get(topic).getPartitionIndex();
-        startMessageId = Optional.of(new MessageIdImpl(11, 10, partitionIndex));
-        String messagePosition = "11:10";
-        mockResult = getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(11, 10),
-                PositionFactory.create(11, 19));
-        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(mockResult);
-
-        cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -p " + messagePosition));
-
-        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
-        verifyNoMoreInteractions(mockTopics);
-
-        // Test client side loop: the loop termination condition is that server returns false aborted flag.
-        reset(mockTopics);
-
-        long backlogScanMaxEntries = 30;
-        startMessageId = Optional.empty();
-        AnalyzeSubscriptionBacklogResult firstResult =
-                getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(12, 0),
-                        PositionFactory.create(12, 9));
-        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(firstResult);
-
-        Optional<MessageId> secondInvocationMsgId = Optional.of(new MessageIdImpl(12, 10, partitionIndex));
-        AnalyzeSubscriptionBacklogResult abortedResult =
-                getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(12, 10),
-                        PositionFactory.create(12, 19));
-        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId)).thenReturn(
-                abortedResult);
-
-        cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries));
-
-        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
-        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId);
-        verifyNoMoreInteractions(mockTopics);
-
-        // Test client side loop: the loop termination condition is that total entries exceeds backlogScanMaxEntries.
-        reset(mockTopics);
-
-        backlogScanMaxEntries = 25;
-        startMessageId = Optional.empty();
-        firstResult = getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(13, 0),
-                PositionFactory.create(13, 9));
-        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(firstResult);
-
-        secondInvocationMsgId = Optional.of(new MessageIdImpl(13, 10, partitionIndex));
-        AnalyzeSubscriptionBacklogResult moreResult =
-                getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(13, 10),
-                        PositionFactory.create(13, 19));
-        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId)).thenReturn(
-                moreResult);
-
-        Optional<MessageId> thirdInvocationMsgId = Optional.of(new MessageIdImpl(13, 20, partitionIndex));
-        AnalyzeSubscriptionBacklogResult lastResult =
-                getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(14, 0),
-                        PositionFactory.create(14, 9));
-        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId)).thenReturn(
-                lastResult);
-
-        cmdTopics.run(
-                split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries + " -q"));
-
-        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
-        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId);
-        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId);
-        verifyNoMoreInteractions(mockTopics);
-    }
-
     private static LedgerInfo newLedger(long id, long entries, long size) {
         LedgerInfo l = new LedgerInfo();
         l.ledgerId = id;
         l.entries = entries;
         l.size = size;
         return l;
-    }
-
-    private AnalyzeSubscriptionBacklogResult getAnalyzeSubscriptionBacklogResult(long entries, boolean aborted,
-                                                                                 Position firstMessageId,
-                                                                                 Position lastMessageId) {
-        AnalyzeSubscriptionBacklogResult result = new AnalyzeSubscriptionBacklogResult();
-        result.setEntries(entries);
-        result.setMessages(entries);
-        result.setAborted(aborted);
-        result.setFirstMessageId(firstMessageId.getLedgerId() + ":" + firstMessageId.getEntryId());
-        result.setLastMessageId(lastMessageId.getLedgerId() + ":" + lastMessageId.getEntryId());
-        return result;
     }
 
     @Test

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -58,6 +58,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.pulsar.admin.cli.extensions.CustomCommandFactory;
 import org.apache.pulsar.admin.cli.utils.SchemaExtractor;
 import org.apache.pulsar.client.admin.Bookies;
@@ -90,6 +92,7 @@ import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
@@ -120,6 +123,7 @@ import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.protocol.schema.PostSchemaPayload;
+import org.apache.pulsar.common.stats.AnalyzeSubscriptionBacklogResult;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -1738,12 +1742,8 @@ public class PulsarAdminToolTest {
         verify(mockTopics).createSubscription("persistent://myprop/ns1/ds1", "sub1",
                 MessageId.earliest, false, null);
 
-        cmdTopics.run(split("analyze-backlog persistent://myprop/ns1/ds1 -s sub1"));
-        verify(mockTopics).analyzeSubscriptionBacklog("persistent://myprop/ns1/ds1", "sub1",
-                Optional.empty());
-
-        cmdTopics.run(split("trim-topic persistent://myprop/ns1/ds1"));
-        verify(mockTopics).trimTopic("persistent://myprop/ns1/ds1");
+        cmdTopics.run(split("trim-topic persistent://myprop/clust/ns1/ds1"));
+        verify(mockTopics).trimTopic("persistent://myprop/clust/ns1/ds1");
 
         // jcommander is stateful, you cannot parse the same command twice
         cmdTopics = new CmdTopics(() -> admin);
@@ -2174,12 +2174,96 @@ public class PulsarAdminToolTest {
 
     }
 
+    @Test
+    public void topicsAnalyzeBacklog() throws Exception {
+        PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
+        Topics mockTopics = mock(Topics.class);
+        when(admin.topics()).thenReturn(mockTopics);
+        CmdTopics cmdTopics = new CmdTopics(() -> admin);
+
+        // Test backward compatibility.
+        String topic = "persistent://myprop/clust/ns1/ds1";
+        String subscriptionName = "sub1";
+        Optional<MessageId> startMessageId = Optional.empty();
+        AnalyzeSubscriptionBacklogResult mockResult =
+                getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(10, 0),
+                        PositionFactory.create(10, 9));
+        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(mockResult);
+        cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName));
+        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
+
+        // Test with the messagePosition parameter.
+        reset(mockTopics);
+        int partitionIndex = TopicName.get(topic).getPartitionIndex();
+        startMessageId = Optional.of(new MessageIdImpl(11, 10, partitionIndex));
+        String messagePosition = "11:10";
+        mockResult = getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(11, 10),
+                PositionFactory.create(11, 19));
+        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(mockResult);
+        cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -p " + messagePosition));
+        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
+
+        // Test client side loop: server returns aborted flag.
+        reset(mockTopics);
+        long backlogScanMaxEntries = 25;
+        startMessageId = Optional.empty();
+        AnalyzeSubscriptionBacklogResult firstResult =
+                getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(12, 0),
+                        PositionFactory.create(12, 9));
+        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(firstResult);
+        Optional<MessageId> secondInvocationMsgId = Optional.of(new MessageIdImpl(12, 10, partitionIndex));
+        AnalyzeSubscriptionBacklogResult abortedResult =
+                getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(12, 10),
+                        PositionFactory.create(12, 19));
+        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId)).thenReturn(
+                abortedResult);
+        cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries));
+        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
+        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId);
+
+        // Test client side loop: total entries exceeds backlogScanMaxEntries.
+        reset(mockTopics);
+        backlogScanMaxEntries = 30;
+        startMessageId = Optional.empty();
+        firstResult = getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(13, 0),
+                PositionFactory.create(13, 9));
+        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(firstResult);
+        secondInvocationMsgId = Optional.of(new MessageIdImpl(13, 10, partitionIndex));
+        AnalyzeSubscriptionBacklogResult moreResult =
+                getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(13, 10),
+                        PositionFactory.create(13, 19));
+        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId)).thenReturn(
+                moreResult);
+        Optional<MessageId> thirdInvocationMsgId = Optional.of(new MessageIdImpl(13, 20, partitionIndex));
+        AnalyzeSubscriptionBacklogResult lastResult =
+                getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(14, 0),
+                        PositionFactory.create(14, 9));
+        when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId)).thenReturn(
+                lastResult);
+        cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries));
+        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
+        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId);
+        verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId);
+    }
+
     private static LedgerInfo newLedger(long id, long entries, long size) {
         LedgerInfo l = new LedgerInfo();
         l.ledgerId = id;
         l.entries = entries;
         l.size = size;
         return l;
+    }
+
+    private AnalyzeSubscriptionBacklogResult getAnalyzeSubscriptionBacklogResult(long entries, boolean aborted,
+                                                                                 Position firstMessageId,
+                                                                                 Position lastMessageId) {
+        AnalyzeSubscriptionBacklogResult result = new AnalyzeSubscriptionBacklogResult();
+        result.setEntries(entries);
+        result.setMessages(entries);
+        result.setAborted(aborted);
+        result.setFirstMessageId(firstMessageId.getLedgerId() + ":" + firstMessageId.getEntryId());
+        result.setLastMessageId(lastMessageId.getLedgerId() + ":" + lastMessageId.getEntryId());
+        return result;
     }
 
     @Test

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -52,6 +52,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -119,6 +120,7 @@ import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.protocol.schema.PostSchemaPayload;
+import org.apache.pulsar.common.stats.AnalyzeSubscriptionBacklogResult;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -1737,6 +1739,10 @@ public class PulsarAdminToolTest {
         verify(mockTopics).createSubscription("persistent://myprop/ns1/ds1", "sub1",
                 MessageId.earliest, false, null);
 
+        cmdTopics.run(split("analyze-backlog persistent://myprop/ns1/ds1 -s sub1"));
+        verify(mockTopics).analyzeSubscriptionBacklog("persistent://myprop/ns1/ds1", "sub1",
+                Optional.empty());
+
         cmdTopics.run(split("trim-topic persistent://myprop/ns1/ds1"));
         verify(mockTopics).trimTopic("persistent://myprop/ns1/ds1");
 
@@ -2314,6 +2320,40 @@ public class PulsarAdminToolTest {
         CmdNonPersistentTopics nonPersistentTopics = new CmdNonPersistentTopics(() -> admin);
         nonPersistentTopics.run(split("list-in-bundle myprop/ns1 --bundle 0x23d70a30_0x26666658"));
         verify(mockNonPersistentTopics).getListInBundle("myprop/ns1", "0x23d70a30_0x26666658");
+    }
+
+    @Test
+    public void topicsAnalyzeBacklogParameterParsing() throws Exception {
+        PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
+        Topics mockTopics = mock(Topics.class);
+        when(admin.topics()).thenReturn(mockTopics);
+
+        AnalyzeSubscriptionBacklogResult backlogResult = new AnalyzeSubscriptionBacklogResult();
+        doReturn(backlogResult).when(mockTopics)
+                .analyzeSubscriptionBacklog(eq("persistent://myprop/ns1/ds1"), eq("sub1"), Mockito.any());
+        doReturn(backlogResult).when(mockTopics)
+                .analyzeSubscriptionBacklog(eq("persistent://myprop/ns1/ds1"), eq("sub1"), Mockito.any(),
+                        Mockito.any());
+
+        CmdTopics cmdTopics = new CmdTopics(() -> admin);
+        cmdTopics.run(split("analyze-backlog persistent://myprop/ns1/ds1 -s sub1 --position 1:1"));
+        verify(mockTopics).analyzeSubscriptionBacklog(eq("persistent://myprop/ns1/ds1"), eq("sub1"),
+                eq(Optional.of(new MessageIdImpl(1, 1, -1))));
+
+        cmdTopics = new CmdTopics(() -> admin);
+        cmdTopics.run(split("analyze-backlog persistent://myprop/ns1/ds1 -s sub1 -b 100 --plain --quiet"));
+        verify(mockTopics).analyzeSubscriptionBacklog(eq("persistent://myprop/ns1/ds1"), eq("sub1"),
+                eq(Optional.empty()), Mockito.any());
+    }
+
+    @Test
+    public void topicsAnalyzeBacklogRejectsNonPositiveBacklogScanMaxEntries() {
+        PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
+        Topics mockTopics = mock(Topics.class);
+        when(admin.topics()).thenReturn(mockTopics);
+
+        CmdTopics cmdTopics = new CmdTopics(() -> admin);
+        assertFalse(cmdTopics.run(split("analyze-backlog persistent://myprop/ns1/ds1 -s sub1 -b 0")));
     }
 
     @Test

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2186,7 +2186,7 @@ public class PulsarAdminToolTest {
         String subscriptionName = "sub1";
         Optional<MessageId> startMessageId = Optional.empty();
         AnalyzeSubscriptionBacklogResult mockResult =
-                getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(10, 0),
+                getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(10, 0),
                         PositionFactory.create(10, 9));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(mockResult);
         cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName));
@@ -2197,23 +2197,23 @@ public class PulsarAdminToolTest {
         int partitionIndex = TopicName.get(topic).getPartitionIndex();
         startMessageId = Optional.of(new MessageIdImpl(11, 10, partitionIndex));
         String messagePosition = "11:10";
-        mockResult = getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(11, 10),
+        mockResult = getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(11, 10),
                 PositionFactory.create(11, 19));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(mockResult);
         cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -p " + messagePosition));
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
 
-        // Test client side loop: server returns aborted flag.
+        // Test client side loop: server returns false aborted flag.
         reset(mockTopics);
-        long backlogScanMaxEntries = 25;
+        long backlogScanMaxEntries = 30;
         startMessageId = Optional.empty();
         AnalyzeSubscriptionBacklogResult firstResult =
-                getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(12, 0),
+                getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(12, 0),
                         PositionFactory.create(12, 9));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(firstResult);
         Optional<MessageId> secondInvocationMsgId = Optional.of(new MessageIdImpl(12, 10, partitionIndex));
         AnalyzeSubscriptionBacklogResult abortedResult =
-                getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(12, 10),
+                getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(12, 10),
                         PositionFactory.create(12, 19));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId)).thenReturn(
                 abortedResult);
@@ -2223,24 +2223,24 @@ public class PulsarAdminToolTest {
 
         // Test client side loop: total entries exceeds backlogScanMaxEntries.
         reset(mockTopics);
-        backlogScanMaxEntries = 30;
+        backlogScanMaxEntries = 25;
         startMessageId = Optional.empty();
-        firstResult = getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(13, 0),
+        firstResult = getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(13, 0),
                 PositionFactory.create(13, 9));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(firstResult);
         secondInvocationMsgId = Optional.of(new MessageIdImpl(13, 10, partitionIndex));
         AnalyzeSubscriptionBacklogResult moreResult =
-                getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(13, 10),
+                getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(13, 10),
                         PositionFactory.create(13, 19));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId)).thenReturn(
                 moreResult);
         Optional<MessageId> thirdInvocationMsgId = Optional.of(new MessageIdImpl(13, 20, partitionIndex));
         AnalyzeSubscriptionBacklogResult lastResult =
-                getAnalyzeSubscriptionBacklogResult(10, false, PositionFactory.create(14, 0),
+                getAnalyzeSubscriptionBacklogResult(10, true, PositionFactory.create(14, 0),
                         PositionFactory.create(14, 9));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId)).thenReturn(
                 lastResult);
-        cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries));
+        cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries + " -q"));
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId);
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1737,8 +1737,8 @@ public class PulsarAdminToolTest {
         verify(mockTopics).createSubscription("persistent://myprop/ns1/ds1", "sub1",
                 MessageId.earliest, false, null);
 
-        cmdTopics.run(split("trim-topic persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopics).trimTopic("persistent://myprop/clust/ns1/ds1");
+        cmdTopics.run(split("trim-topic persistent://myprop/ns1/ds1"));
+        verify(mockTopics).trimTopic("persistent://myprop/ns1/ds1");
 
         // jcommander is stateful, you cannot parse the same command twice
         cmdTopics = new CmdTopics(() -> admin);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -2191,6 +2192,7 @@ public class PulsarAdminToolTest {
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(mockResult);
         cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName));
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
+        verifyNoMoreInteractions(mockTopics);
 
         // Test with the messagePosition parameter.
         reset(mockTopics);
@@ -2202,6 +2204,7 @@ public class PulsarAdminToolTest {
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId)).thenReturn(mockResult);
         cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -p " + messagePosition));
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
+        verifyNoMoreInteractions(mockTopics);
 
         // Test client side loop: server returns false aborted flag.
         reset(mockTopics);
@@ -2220,6 +2223,7 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries));
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId);
+        verifyNoMoreInteractions(mockTopics);
 
         // Test client side loop: total entries exceeds backlogScanMaxEntries.
         reset(mockTopics);
@@ -2245,6 +2249,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId);
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId);
+        verifyNoMoreInteractions(mockTopics);
     }
 
     private static LedgerInfo newLedger(long id, long entries, long size) {

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2240,7 +2240,8 @@ public class PulsarAdminToolTest {
                         PositionFactory.create(14, 9));
         when(mockTopics.analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId)).thenReturn(
                 lastResult);
-        cmdTopics.run(split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries + " -q"));
+        cmdTopics.run(
+                split("analyze-backlog " + topic + " -s " + subscriptionName + " -b " + backlogScanMaxEntries + " -q"));
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, startMessageId);
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, secondInvocationMsgId);
         verify(mockTopics, times(1)).analyzeSubscriptionBacklog(topic, subscriptionName, thirdInvocationMsgId);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -120,7 +120,7 @@ public abstract class CliCommand implements Callable<Integer> {
             } else if (prettyPrint) {
                 prettyPrint(item);
             } else {
-                commandSpec.commandLine().getOut().println(MAPPER.writeValueAsString(item));
+                plainPrint(item);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -110,11 +110,17 @@ public abstract class CliCommand implements Callable<Integer> {
     }
 
     <T> void print(T item) {
+        print(item, true);
+    }
+
+    <T> void print(T item, boolean prettyPrint) {
         try {
             if (item instanceof String) {
                 commandSpec.commandLine().getOut().println(item);
-            } else {
+            } else if (prettyPrint) {
                 prettyPrint(item);
+            } else {
+                commandSpec.commandLine().getOut().println(MAPPER.writeValueAsString(item));
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -124,6 +130,14 @@ public abstract class CliCommand implements Callable<Integer> {
     <T> void prettyPrint(T item) {
         try {
             commandSpec.commandLine().getOut().println(WRITER.writeValueAsString(item));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    <T> void plainPrint(T item) {
+        try {
+            commandSpec.commandLine().getOut().println(MAPPER.writeValueAsString(item));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -3010,7 +3010,7 @@ public class CmdTopics extends CmdBase {
                 "-p" }, description = "Message position to start the scan from (ledgerId:entryId)", required = false)
         private String messagePosition;
 
-        @Option(names = {"--backlogScanMaxEntries", "-b"}, description =
+        @Option(names = {"--backlog-scan-max-entries", "-b"}, description =
                 "The maximum number of backlog entries the client will scan before terminating its loop",
                 required = false)
         private long backlogScanMaxEntries = -1;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -3062,6 +3062,12 @@ public class CmdTopics extends CmdBase {
                     break;
                 }
 
+                // To avoid infinite loops, we ensure the entry count is incremented after each loop.
+                if (currentResult.getEntries() <= 0) {
+                    print("Incorrect total entry count returned from server");
+                    return;
+                }
+
                 // In analyze-backlog, lastMessageId is null only when: total entries is 0,
                 // with false aborted flag returned.
                 if (StringUtils.isBlank(mergedResult.getLastMessageId())) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -83,6 +83,7 @@ import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PublishRate;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
+import org.apache.pulsar.common.stats.AnalyzeSubscriptionBacklogResult;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import picocli.CommandLine.Command;
@@ -3006,20 +3007,75 @@ public class CmdTopics extends CmdBase {
         private String subName;
 
         @Option(names = { "--position",
-                "-p" }, description = "message position to start the scan from (ledgerId:entryId)", required = false)
+                "-p" }, description = "Message position to start the scan from (ledgerId:entryId)", required = false)
         private String messagePosition;
+
+        @Option(names = {"--backlogScanMaxEntries", "-b"}, description =
+                "The maximum number of backlog entries the client will scan before terminating its loop",
+                required = false)
+        private long backlogScanMaxEntries = -1;
+
+        @Option(names = {"--quiet", "-q"}, description =
+                "Disable analyze-backlog progress reporting",
+                required = false)
+        private boolean quiet = false;
 
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(topicName);
             Optional<MessageId> startPosition = Optional.empty();
+            int partitionIndex = TopicName.get(persistentTopic).getPartitionIndex();
             if (isNotBlank(messagePosition)) {
-                int partitionIndex = TopicName.get(persistentTopic).getPartitionIndex();
                 MessageId messageId = validateMessageIdString(messagePosition, partitionIndex);
                 startPosition = Optional.of(messageId);
             }
-            print(getTopics().analyzeSubscriptionBacklog(persistentTopic, subName, startPosition));
 
+            AnalyzeSubscriptionBacklogResult mergedResult = null;
+            while (true) {
+                AnalyzeSubscriptionBacklogResult currentResult =
+                        getTopics().analyzeSubscriptionBacklog(persistentTopic, subName, startPosition);
+                if (mergedResult == null) {
+                    mergedResult = currentResult;
+                } else {
+                    mergedResult.setEntries(mergedResult.getEntries() + currentResult.getEntries());
+                    mergedResult.setMessages(mergedResult.getMessages() + currentResult.getMessages());
+                    mergedResult.setMarkerMessages(
+                            mergedResult.getMarkerMessages() + currentResult.getMarkerMessages());
+
+                    mergedResult.setFilterRejectedEntries(
+                            mergedResult.getFilterRejectedEntries() + currentResult.getFilterRejectedEntries());
+                    mergedResult.setFilterAcceptedEntries(
+                            mergedResult.getFilterAcceptedEntries() + currentResult.getFilterAcceptedEntries());
+                    mergedResult.setFilterRescheduledEntries(
+                            mergedResult.getFilterRescheduledEntries() + currentResult.getFilterRescheduledEntries());
+
+                    mergedResult.setFilterRejectedMessages(
+                            mergedResult.getFilterRejectedMessages() + currentResult.getFilterRejectedMessages());
+                    mergedResult.setFilterAcceptedMessages(
+                            mergedResult.getFilterAcceptedMessages() + currentResult.getFilterAcceptedMessages());
+                    mergedResult.setFilterRescheduledMessages(
+                            mergedResult.getFilterRescheduledMessages() + currentResult.getFilterRescheduledMessages());
+
+                    mergedResult.setAborted(currentResult.isAborted());
+                    mergedResult.setLastMessageId(currentResult.getLastMessageId());
+                }
+
+                if (mergedResult.isAborted() || mergedResult.getEntries() >= backlogScanMaxEntries) {
+                    break;
+                }
+
+                if (!quiet) {
+                    print("Analyze backlog progress, scanned entries: " + mergedResult.getEntries()
+                            + ", scan max entries: " + backlogScanMaxEntries);
+                }
+
+                String[] messageIdSplits = mergedResult.getLastMessageId().split(":");
+                MessageIdImpl nextScanMessageId =
+                        new MessageIdImpl(Long.parseLong(messageIdSplits[0]), Long.parseLong(messageIdSplits[1]) + 1,
+                                partitionIndex);
+                startPosition = Optional.of(nextScanMessageId);
+            }
+            print(mergedResult);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -3015,9 +3015,7 @@ public class CmdTopics extends CmdBase {
                 required = false)
         private long backlogScanMaxEntries = -1;
 
-        @Option(names = {"--quiet", "-q"}, description =
-                "Disable analyze-backlog progress reporting",
-                required = false)
+        @Option(names = {"--quiet", "-q"}, description = "Disable analyze-backlog progress reporting", required = false)
         private boolean quiet = false;
 
         @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -3058,7 +3058,7 @@ public class CmdTopics extends CmdBase {
                     mergedResult.setLastMessageId(currentResult.getLastMessageId());
                 }
 
-                if (mergedResult.isAborted() || mergedResult.getEntries() >= backlogScanMaxEntries) {
+                if (!mergedResult.isAborted() || mergedResult.getEntries() >= backlogScanMaxEntries) {
                     break;
                 }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -3013,13 +3013,13 @@ public class CmdTopics extends CmdBase {
         @Option(names = {"--backlog-scan-max-entries",
                 "-b"}, description = "The maximum number of backlog entries the client will scan before terminating "
                 + "its loop", required = false)
-        private long backlogScanMaxEntries = -1;
+        private Long backlogScanMaxEntries;
 
         @Option(names = {"--quiet", "-q"}, description = "Disable analyze-backlog progress reporting", required = false)
         private boolean quiet = false;
 
-        @Option(names = {"--plain-print",
-                "-pp"}, description = "Plain(Non-pretty) print the final result output as NDJSON", required = false)
+        @Option(names = {"--plain"}, description = "Plain(Non-pretty) print backlog results as NDJSON",
+                required = false)
         private boolean plainPrint = false;
 
         @Override
@@ -3032,14 +3032,22 @@ public class CmdTopics extends CmdBase {
                 startPosition = Optional.of(messageId);
             }
 
-            AnalyzeSubscriptionBacklogResult backlogResult =
-                    getTopics().analyzeSubscriptionBacklogAsync(persistentTopic, subName, startPosition, result -> {
-                        boolean terminate = result.getEntries() >= backlogScanMaxEntries;
-                        if (!quiet && !terminate) {
-                            print(result, false);
-                        }
-                        return terminate;
-                    }).get();
+            AnalyzeSubscriptionBacklogResult backlogResult;
+            if (backlogScanMaxEntries == null) {
+                backlogResult = getTopics().analyzeSubscriptionBacklog(persistentTopic, subName, startPosition);
+            } else {
+                if (backlogScanMaxEntries <= 0) {
+                    throw new ParameterException("--backlog-scan-max-entries must be greater than 0");
+                }
+                backlogResult = getTopics().analyzeSubscriptionBacklog(persistentTopic, subName, startPosition,
+                        result -> {
+                            boolean terminate = result.getEntries() >= backlogScanMaxEntries;
+                            if (!quiet && !terminate) {
+                                print(result, !plainPrint);
+                            }
+                            return terminate;
+                        });
+            }
             print(backlogResult, !plainPrint);
         }
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -3018,9 +3018,9 @@ public class CmdTopics extends CmdBase {
         @Option(names = {"--quiet", "-q"}, description = "Disable analyze-backlog progress reporting", required = false)
         private boolean quiet = false;
 
-        @Option(names = {"--pretty-print",
-                "-pp"}, description = "Pretty print the final result output", required = false)
-        private boolean prettyPrint = true;
+        @Option(names = {"--plain-print",
+                "-pp"}, description = "Plain(Non-pretty) print the final result output as NDJSON", required = false)
+        private boolean plainPrint = false;
 
         @Override
         void run() throws Exception {
@@ -3040,7 +3040,7 @@ public class CmdTopics extends CmdBase {
                         }
                         return terminate;
                     }).get();
-            print(backlogResult, prettyPrint);
+            print(backlogResult, !plainPrint);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -3062,6 +3062,13 @@ public class CmdTopics extends CmdBase {
                     break;
                 }
 
+                // In analyze-backlog, lastMessageId is null only when: total entries is 0,
+                // with false aborted flag returned.
+                if (StringUtils.isBlank(mergedResult.getLastMessageId())) {
+                    print("Incorrect last message id returned from server");
+                    return;
+                }
+
                 if (!quiet) {
                     print("Analyze backlog progress, scanned entries: " + mergedResult.getEntries()
                             + ", scan max entries: " + backlogScanMaxEntries);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -3003,23 +3003,27 @@ public class CmdTopics extends CmdBase {
         @Parameters(description = "persistent://tenant/namespace/topic", arity = "1")
         private String topicName;
 
-        @Option(names = { "-s", "--subscription" }, description = "Subscription to be analyzed", required = true)
+        @Option(names = {"-s", "--subscription"}, description = "Subscription to be analyzed", required = true)
         private String subName;
 
-        @Option(names = { "--position",
-                "-p" }, description = "Message position to start the scan from (ledgerId:entryId)", required = false)
+        @Option(names = {"--position",
+                "-p"}, description = "Message position to start the scan from (ledgerId:entryId)", required = false)
         private String messagePosition;
 
-        @Option(names = {"--backlog-scan-max-entries", "-b"}, description =
-                "The maximum number of backlog entries the client will scan before terminating its loop",
-                required = false)
+        @Option(names = {"--backlog-scan-max-entries",
+                "-b"}, description = "The maximum number of backlog entries the client will scan before terminating "
+                + "its loop", required = false)
         private long backlogScanMaxEntries = -1;
 
         @Option(names = {"--quiet", "-q"}, description = "Disable analyze-backlog progress reporting", required = false)
         private boolean quiet = false;
 
+        @Option(names = {"--pretty-print",
+                "-pp"}, description = "Pretty print the final result output", required = false)
+        private boolean prettyPrint = true;
+
         @Override
-        void run() throws PulsarAdminException {
+        void run() throws Exception {
             String persistentTopic = validatePersistentTopic(topicName);
             Optional<MessageId> startPosition = Optional.empty();
             int partitionIndex = TopicName.get(persistentTopic).getPartitionIndex();
@@ -3028,65 +3032,15 @@ public class CmdTopics extends CmdBase {
                 startPosition = Optional.of(messageId);
             }
 
-            AnalyzeSubscriptionBacklogResult mergedResult = null;
-            while (true) {
-                AnalyzeSubscriptionBacklogResult currentResult =
-                        getTopics().analyzeSubscriptionBacklog(persistentTopic, subName, startPosition);
-                if (mergedResult == null) {
-                    mergedResult = currentResult;
-                } else {
-                    mergedResult.setEntries(mergedResult.getEntries() + currentResult.getEntries());
-                    mergedResult.setMessages(mergedResult.getMessages() + currentResult.getMessages());
-                    mergedResult.setMarkerMessages(
-                            mergedResult.getMarkerMessages() + currentResult.getMarkerMessages());
-
-                    mergedResult.setFilterRejectedEntries(
-                            mergedResult.getFilterRejectedEntries() + currentResult.getFilterRejectedEntries());
-                    mergedResult.setFilterAcceptedEntries(
-                            mergedResult.getFilterAcceptedEntries() + currentResult.getFilterAcceptedEntries());
-                    mergedResult.setFilterRescheduledEntries(
-                            mergedResult.getFilterRescheduledEntries() + currentResult.getFilterRescheduledEntries());
-
-                    mergedResult.setFilterRejectedMessages(
-                            mergedResult.getFilterRejectedMessages() + currentResult.getFilterRejectedMessages());
-                    mergedResult.setFilterAcceptedMessages(
-                            mergedResult.getFilterAcceptedMessages() + currentResult.getFilterAcceptedMessages());
-                    mergedResult.setFilterRescheduledMessages(
-                            mergedResult.getFilterRescheduledMessages() + currentResult.getFilterRescheduledMessages());
-
-                    mergedResult.setAborted(currentResult.isAborted());
-                    mergedResult.setLastMessageId(currentResult.getLastMessageId());
-                }
-
-                if (!mergedResult.isAborted() || mergedResult.getEntries() >= backlogScanMaxEntries) {
-                    break;
-                }
-
-                // To avoid infinite loops, we ensure the entry count is incremented after each loop.
-                if (currentResult.getEntries() <= 0) {
-                    print("Incorrect total entry count returned from server");
-                    return;
-                }
-
-                // In analyze-backlog, lastMessageId is null only when: total entries is 0,
-                // with false aborted flag returned.
-                if (StringUtils.isBlank(mergedResult.getLastMessageId())) {
-                    print("Incorrect last message id returned from server");
-                    return;
-                }
-
-                if (!quiet) {
-                    print("Analyze backlog progress, scanned entries: " + mergedResult.getEntries()
-                            + ", scan max entries: " + backlogScanMaxEntries);
-                }
-
-                String[] messageIdSplits = mergedResult.getLastMessageId().split(":");
-                MessageIdImpl nextScanMessageId =
-                        new MessageIdImpl(Long.parseLong(messageIdSplits[0]), Long.parseLong(messageIdSplits[1]) + 1,
-                                partitionIndex);
-                startPosition = Optional.of(nextScanMessageId);
-            }
-            print(mergedResult);
+            AnalyzeSubscriptionBacklogResult backlogResult =
+                    getTopics().analyzeSubscriptionBacklogAsync(persistentTopic, subName, startPosition, result -> {
+                        boolean terminate = result.getEntries() >= backlogScanMaxEntries;
+                        if (!quiet && !terminate) {
+                            print(result, false);
+                        }
+                        return terminate;
+                    }).get();
+            print(backlogResult, prettyPrint);
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
@@ -56,7 +56,7 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
         prepareSubscriptionBacklog(SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES + 1);
 
         ContainerExecResult result =
-                pulsarCluster.runAdminCommandOnAnyBroker("analyze-backlog", TOPICS_CMD, ANALYZE_BACKLOG_TOPIC_NAME,
+                pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
                         "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME);
 
         String stdout = result.getStdout();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
@@ -74,7 +74,7 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
 
         ContainerExecResult result =
                 pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
-                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-pp", "false");
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-pp");
 
         String stdout = result.getStdout();
         AnalyzeSubscriptionBacklogResult backlogResult =
@@ -92,7 +92,7 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
 
         ContainerExecResult result =
                 pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
-                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-pp", "false");
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-b", String.valueOf(backlogNum), "-pp");
 
         int expectedResultLines = 4;
         String stdout = result.getStdout();
@@ -113,7 +113,7 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
 
         ContainerExecResult result =
                 pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
-                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-q", "true", "-pp", "false");
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-b", String.valueOf(backlogNum), "-q", "-pp");
 
         String stdout = result.getStdout();
         String[] lines = stdout.split(LINE_SEPARATOR_REGEX);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.cli.topic;
+
+import static org.testng.AssertJUnit.assertEquals;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.Cleanup;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.common.stats.AnalyzeSubscriptionBacklogResult;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
+import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
+import org.testng.annotations.Test;
+
+public class AnalyzeBacklogTest extends PulsarTestSuite {
+
+    private static final String PREFIX = "PULSAR_PREFIX_";
+    private static final String ANALYZE_BACKLOG_TOPIC_NAME = "tenant/ns/analyze-backlog-topic";
+    private static final String ANALYZE_BACKLOG_SUBSCRIPTION_NAME = "sub1";
+    private static final int SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES = 10;
+
+    @Override
+    public void setupCluster() throws Exception {
+        brokerEnvs.put(PREFIX + "subscriptionBacklogScanMaxEntries",
+                String.valueOf(SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES));
+        super.setupCluster();
+    }
+
+    @Test
+    public void testAnalyzeBacklog() throws Exception {
+        prepareSubscriptionBacklog(SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES + 1);
+
+        ContainerExecResult result =
+                pulsarCluster.runAdminCommandOnAnyBroker("analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME, "-s",
+                        ANALYZE_BACKLOG_SUBSCRIPTION_NAME);
+        AnalyzeSubscriptionBacklogResult backlogResult =
+                jsonMapper().readValue(result.getStdout(), AnalyzeSubscriptionBacklogResult.class);
+
+        assertEquals(SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES, backlogResult.getEntries());
+    }
+
+    private void prepareSubscriptionBacklog(int backlogNum) throws Exception {
+        @Cleanup
+        PulsarClient client = PulsarClient.builder().serviceUrl(pulsarCluster.getPlainTextServiceUrl()).build();
+        @Cleanup
+        Producer<byte[]> producer = client.newProducer().topic(ANALYZE_BACKLOG_TOPIC_NAME).create();
+        @Cleanup
+        Consumer<byte[]> consumer = client.newConsumer().topic(ANALYZE_BACKLOG_TOPIC_NAME)
+                .subscriptionName(ANALYZE_BACKLOG_SUBSCRIPTION_NAME).subscribe();
+
+        List<CompletableFuture<MessageId>> futures = new ArrayList<>(backlogNum);
+        for (int i = 0; i < backlogNum; i++) {
+            byte[] msgBytes = ("test" + i).getBytes(StandardCharsets.UTF_8);
+            CompletableFuture<MessageId> future = producer.sendAsync(msgBytes);
+            futures.add(future);
+        }
+        FutureUtil.waitForAll(futures).get();
+    }
+
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
@@ -42,6 +42,7 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
     private static final String ANALYZE_BACKLOG_SUBSCRIPTION_NAME = "sub1";
     private static final int SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES = 10;
     private static final String LINE_SEPARATOR_REGEX = "\\r?\\n";
+    private static final String TOPICS_CMD = "topics";
 
     @Override
     public void setupCluster() throws Exception {
@@ -55,8 +56,8 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
         prepareSubscriptionBacklog(SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES + 1);
 
         ContainerExecResult result =
-                pulsarCluster.runAdminCommandOnAnyBroker("analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME, "-s",
-                        ANALYZE_BACKLOG_SUBSCRIPTION_NAME);
+                pulsarCluster.runAdminCommandOnAnyBroker("analyze-backlog", TOPICS_CMD, ANALYZE_BACKLOG_TOPIC_NAME,
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME);
 
         String stdout = result.getStdout();
         AnalyzeSubscriptionBacklogResult backlogResult =

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.tests.integration.cli.topic;
 
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,9 +38,10 @@ import org.testng.annotations.Test;
 public class AnalyzeBacklogTest extends PulsarTestSuite {
 
     private static final String PREFIX = "PULSAR_PREFIX_";
-    private static final String ANALYZE_BACKLOG_TOPIC_NAME = "tenant/ns/analyze-backlog-topic";
+    private static final String ANALYZE_BACKLOG_TOPIC_NAME = "public/default/analyze-backlog-topic";
     private static final String ANALYZE_BACKLOG_SUBSCRIPTION_NAME = "sub1";
     private static final int SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES = 10;
+    private static final String LINE_SEPARATOR_REGEX = "\\r?\\n";
 
     @Override
     public void setupCluster() throws Exception {
@@ -55,10 +57,14 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
         ContainerExecResult result =
                 pulsarCluster.runAdminCommandOnAnyBroker("analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME, "-s",
                         ANALYZE_BACKLOG_SUBSCRIPTION_NAME);
-        AnalyzeSubscriptionBacklogResult backlogResult =
-                jsonMapper().readValue(result.getStdout(), AnalyzeSubscriptionBacklogResult.class);
 
+        String stdout = result.getStdout();
+        AnalyzeSubscriptionBacklogResult backlogResult =
+                jsonMapper().readValue(stdout, AnalyzeSubscriptionBacklogResult.class);
         assertEquals(SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES, backlogResult.getEntries());
+
+        String[] lines = stdout.split(LINE_SEPARATOR_REGEX);
+        assertTrue(lines.length > 1);
     }
 
     private void prepareSubscriptionBacklog(int backlogNum) throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
@@ -99,10 +99,10 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
         String[] lines = stdout.split(LINE_SEPARATOR_REGEX);
         assertEquals(expectedResultLines, lines.length);
 
-        for (int i = 1; i <= expectedResultLines; i++) {
+        for (int i = 0; i < expectedResultLines; i++) {
             AnalyzeSubscriptionBacklogResult backlogResult =
                     jsonMapper().readValue(lines[i], AnalyzeSubscriptionBacklogResult.class);
-            assertEquals((long) SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES * i, backlogResult.getEntries());
+            assertEquals((long) SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES * (i + 1), backlogResult.getEntries());
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
@@ -72,7 +72,8 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
         @Cleanup
         PulsarClient client = PulsarClient.builder().serviceUrl(pulsarCluster.getPlainTextServiceUrl()).build();
         @Cleanup
-        Producer<byte[]> producer = client.newProducer().topic(ANALYZE_BACKLOG_TOPIC_NAME).create();
+        Producer<byte[]> producer =
+                client.newProducer().topic(ANALYZE_BACKLOG_TOPIC_NAME).enableBatching(false).create();
         @Cleanup
         Consumer<byte[]> consumer = client.newConsumer().topic(ANALYZE_BACKLOG_TOPIC_NAME)
                 .subscriptionName(ANALYZE_BACKLOG_SUBSCRIPTION_NAME).subscribe();

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
@@ -87,12 +87,13 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
 
     @Test
     public void testAnalyzeBacklogClientSideLoopUsingPlainPrint() throws Exception {
-        int backlogNum = 35;
+        int backlogNum = 50;
         prepareSubscriptionBacklog(backlogNum);
 
+        int backlogScanMaxEntries = 40;
         ContainerExecResult result =
                 pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
-                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-b", String.valueOf(backlogNum), "-pp");
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-b", String.valueOf(backlogScanMaxEntries), "-pp");
 
         int expectedResultLines = 4;
         String stdout = result.getStdout();
@@ -108,20 +109,23 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
 
     @Test
     public void testAnalyzeBacklogClientSideLoopUsingQuietPlainPrint() throws Exception {
-        int backlogNum = 30;
+        int backlogNum = 50;
         prepareSubscriptionBacklog(backlogNum);
 
+        int backlogScanMaxEntries = 35;
         ContainerExecResult result =
                 pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
-                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-b", String.valueOf(backlogNum), "-q", "-pp");
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-b", String.valueOf(backlogScanMaxEntries), "-q",
+                        "-pp");
 
         String stdout = result.getStdout();
         String[] lines = stdout.split(LINE_SEPARATOR_REGEX);
         assertEquals(1, lines.length);
 
+        int expectedEntries = 40;
         AnalyzeSubscriptionBacklogResult backlogResult =
                 jsonMapper().readValue(stdout, AnalyzeSubscriptionBacklogResult.class);
-        assertEquals(backlogNum, backlogResult.getEntries());
+        assertEquals(expectedEntries, backlogResult.getEntries());
     }
 
     private void prepareSubscriptionBacklog(int backlogNum) throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
@@ -52,7 +52,7 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
     }
 
     @Test
-    public void testAnalyzeBacklog() throws Exception {
+    public void testAnalyzeBacklogUsingDefaultConfig() throws Exception {
         prepareSubscriptionBacklog(SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES + 1);
 
         ContainerExecResult result =
@@ -66,6 +66,62 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
 
         String[] lines = stdout.split(LINE_SEPARATOR_REGEX);
         assertTrue(lines.length > 1);
+    }
+
+    @Test
+    public void testAnalyzeBacklogUsingPlainPrint() throws Exception {
+        prepareSubscriptionBacklog(SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES + 1);
+
+        ContainerExecResult result =
+                pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-pp", "false");
+
+        String stdout = result.getStdout();
+        AnalyzeSubscriptionBacklogResult backlogResult =
+                jsonMapper().readValue(stdout, AnalyzeSubscriptionBacklogResult.class);
+        assertEquals(SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES, backlogResult.getEntries());
+
+        String[] lines = stdout.split(LINE_SEPARATOR_REGEX);
+        assertEquals(1, lines.length);
+    }
+
+    @Test
+    public void testAnalyzeBacklogClientSideLoopUsingPlainPrint() throws Exception {
+        int backlogNum = 35;
+        prepareSubscriptionBacklog(backlogNum);
+
+        ContainerExecResult result =
+                pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-pp", "false");
+
+        int expectedResultLines = 4;
+        String stdout = result.getStdout();
+        String[] lines = stdout.split(LINE_SEPARATOR_REGEX);
+        assertEquals(expectedResultLines, lines.length);
+
+        for (int i = 1; i <= expectedResultLines; i++) {
+            AnalyzeSubscriptionBacklogResult backlogResult =
+                    jsonMapper().readValue(lines[i], AnalyzeSubscriptionBacklogResult.class);
+            assertEquals((long) SUBSCRIPTION_BACKLOG_SCAN_MAX_ENTRIES * i, backlogResult.getEntries());
+        }
+    }
+
+    @Test
+    public void testAnalyzeBacklogClientSideLoopUsingQuietPlainPrint() throws Exception {
+        int backlogNum = 30;
+        prepareSubscriptionBacklog(backlogNum);
+
+        ContainerExecResult result =
+                pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-q", "true", "-pp", "false");
+
+        String stdout = result.getStdout();
+        String[] lines = stdout.split(LINE_SEPARATOR_REGEX);
+        assertEquals(1, lines.length);
+
+        AnalyzeSubscriptionBacklogResult backlogResult =
+                jsonMapper().readValue(stdout, AnalyzeSubscriptionBacklogResult.class);
+        assertEquals(backlogNum, backlogResult.getEntries());
     }
 
     private void prepareSubscriptionBacklog(int backlogNum) throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/topic/AnalyzeBacklogTest.java
@@ -74,7 +74,7 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
 
         ContainerExecResult result =
                 pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
-                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-pp");
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "--plain");
 
         String stdout = result.getStdout();
         AnalyzeSubscriptionBacklogResult backlogResult =
@@ -93,7 +93,8 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
         int backlogScanMaxEntries = 40;
         ContainerExecResult result =
                 pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
-                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-b", String.valueOf(backlogScanMaxEntries), "-pp");
+                        "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-b", String.valueOf(backlogScanMaxEntries),
+                        "--plain");
 
         int expectedResultLines = 4;
         String stdout = result.getStdout();
@@ -116,7 +117,7 @@ public class AnalyzeBacklogTest extends PulsarTestSuite {
         ContainerExecResult result =
                 pulsarCluster.runAdminCommandOnAnyBroker(TOPICS_CMD, "analyze-backlog", ANALYZE_BACKLOG_TOPIC_NAME,
                         "-s", ANALYZE_BACKLOG_SUBSCRIPTION_NAME, "-b", String.valueOf(backlogScanMaxEntries), "-q",
-                        "-pp");
+                        "--plain");
 
         String stdout = result.getStdout();
         String[] lines = stdout.split(LINE_SEPARATOR_REGEX);

--- a/tests/integration/src/test/resources/pulsar-cli.xml
+++ b/tests/integration/src/test/resources/pulsar-cli.xml
@@ -34,6 +34,7 @@
             <class name="org.apache.pulsar.tests.integration.cli.tenant.TenantTest"/>
             <class name="org.apache.pulsar.tests.integration.cli.PerfToolTest"/>
             <class name="org.apache.pulsar.tests.integration.cli.topicpolicies.SchemaCompatibilityStrategyTest"/>
+            <class name="org.apache.pulsar.tests.integration.cli.topic.AnalyzeBacklogTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar/issues/25083

### Motivation

Use client-side looping instead of increasing broker settings to avoid potential HTTP call timeout in "pulsar-admin topics analyze-backlog" cli.

### Modifications

Add client-side looping, add test.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
