### PR TITLE
[improve][admin] Add client side looping to analyze-backlog in Topics to avoid potential HTTP call timeout

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpScan.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpScan.java
@@ -69,6 +69,7 @@ class OpScan implements ReadEntriesCallback {
         try {
             Position lastPositionForBatch = entries.get(entries.size() - 1).getPosition();
             lastSeenPosition = lastPositionForBatch;
+            // TODO This filter operation is not needed, already handled by OpReadEntry.
             // filter out the entry if it has been already deleted
             // filterReadEntries will call entry.release if the entry is filtered out
             List<Entry> entriesFiltered = this.cursor.filterReadEntries(entries);
@@ -76,7 +77,7 @@ class OpScan implements ReadEntriesCallback {
             remainingEntries.addAndGet(-skippedEntries);
             if (!entriesFiltered.isEmpty()) {
                 for (Entry entry : entriesFiltered) {
-                    if (remainingEntries.decrementAndGet() <= 0) {
+                    if (remainingEntries.getAndDecrement() <= 0) {
                         log.warn("[{}] Scan abort after reading too many entries", OpScan.this.cursor);
                         callback.scanComplete(lastSeenPosition, ScanOutcome.ABORTED, OpScan.this.ctx);
                         return;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpScan.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpScan.java
@@ -91,7 +91,8 @@ class OpScan implements ReadEntriesCallback {
             searchPosition = ledger.getPositionAfterN(lastPositionForBatch, 1,
                     PositionBound.startExcluded);
             if (log.isDebugEnabled()) {
-                log.debug("readEntryComplete {} at {} next is {}", lastPositionForBatch, searchPosition);
+                log.debug("[{}] readEntryComplete at {} next is {}", OpScan.this.cursor, lastPositionForBatch,
+                        searchPosition);
             }
 
             if (searchPosition.compareTo(lastPositionForBatch) == 0) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpScan.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpScan.java
@@ -71,12 +71,12 @@ class OpScan implements ReadEntriesCallback {
             lastSeenPosition = lastPositionForBatch;
             for (Entry entry : entries) {
                 if (remainingEntries.getAndDecrement() <= 0) {
-                    log.warn("[{}] Scan abort after reading too many entries", OpScan.this.cursor);
+                    log.info("[{}] Scan abort after reading too many entries", OpScan.this.cursor);
                     callback.scanComplete(lastSeenPosition, ScanOutcome.ABORTED, OpScan.this.ctx);
                     return;
                 }
                 if (!condition.test(entry)) {
-                    log.warn("[{}] Scan abort due to user code", OpScan.this.cursor);
+                    log.info("[{}] Scan abort due to user code", OpScan.this.cursor);
                     callback.scanComplete(lastSeenPosition, ScanOutcome.USER_INTERRUPTED, OpScan.this.ctx);
                     return;
                 }
@@ -111,12 +111,12 @@ class OpScan implements ReadEntriesCallback {
 
     public void find() {
         if (remainingEntries.get() <= 0) {
-            log.warn("[{}] Scan abort after reading too many entries", OpScan.this.cursor);
+            log.info("[{}] Scan abort after reading too many entries", OpScan.this.cursor);
             callback.scanComplete(lastSeenPosition, ScanOutcome.ABORTED, OpScan.this.ctx);
             return;
         }
         if (System.currentTimeMillis() - startTime > timeOutMs) {
-            log.warn("[{}] Scan abort after hitting the deadline", OpScan.this.cursor);
+            log.info("[{}] Scan abort after hitting the deadline", OpScan.this.cursor);
             callback.scanComplete(lastSeenPosition, ScanOutcome.ABORTED, OpScan.this.ctx);
             return;
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AnalyzeBacklogSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AnalyzeBacklogSubscriptionTest.java
@@ -324,7 +324,7 @@ public class AnalyzeBacklogSubscriptionTest extends ProducerConsumerBase {
         // Test client side loop with individual ack.
         clientSideLoopAnalyzeBacklogSetup(topic, subName, messages);
 
-        // we want to wait for the server to process acks, in order to not have a flaky test.
+        // We want to wait for the server to process acks, in order to not have a flaky test.
         @Cleanup Consumer<byte[]> consumer =
                 pulsarClient.newConsumer().topic(topic).isAckReceiptEnabled(true).subscriptionName(subName)
                         .subscriptionType(SubscriptionType.Shared).subscribe();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AnalyzeBacklogSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AnalyzeBacklogSubscriptionTest.java
@@ -338,11 +338,11 @@ public class AnalyzeBacklogSubscriptionTest extends ProducerConsumerBase {
             consumer.acknowledge(message);
         }
 
-        verifyClientSideLoopBacklog(topic, subName, backlogScanMaxEntries, 0, null,
-                null);
+        verifyClientSideLoopBacklog(topic, subName, backlogScanMaxEntries, 0, null, null);
     }
 
-    private List<MessageId> clientSideLoopAnalyzeBacklogSetup(String topic, String subName, int numMessages) throws Exception {
+    private List<MessageId> clientSideLoopAnalyzeBacklogSetup(String topic, String subName, int numMessages)
+            throws Exception {
         admin.topics().createSubscription(topic, subName, MessageId.latest);
 
         assertEquals(admin.topics().getSubscriptions(topic), List.of("sub-1"));
@@ -359,8 +359,8 @@ public class AnalyzeBacklogSubscriptionTest extends ProducerConsumerBase {
     }
 
     private void verifyClientSideLoopBacklog(String topic, String subName, int backlogMaxScanEntries,
-                                                    int expectedEntries, MessageId firstMessageId,
-                                                    MessageId lastMessageId) throws Exception {
+                                             int expectedEntries, MessageId firstMessageId, MessageId lastMessageId)
+            throws Exception {
         AnalyzeSubscriptionBacklogResult backlogResult =
                 admin.topics().analyzeSubscriptionBacklog(topic, subName, Optional.empty(), backlogMaxScanEntries);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AnalyzeBacklogSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AnalyzeBacklogSubscriptionTest.java
@@ -320,7 +320,7 @@ public class AnalyzeBacklogSubscriptionTest extends ProducerConsumerBase {
         long serverSubscriptionBacklogScanMaxEntries = 20;
         conf.setSubscriptionBacklogScanMaxEntries(serverSubscriptionBacklogScanMaxEntries);
 
-        String topic = "persistent://my-property/my-ns/analyze-backlog-with-topic-Unloaded";
+        String topic = "persistent://my-property/my-ns/analyze-backlog-with-individual-ack";
         String subName = "sub-1";
         int messages = 55;
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -2220,6 +2220,29 @@ public interface Topics {
      * This is a potentially expensive operation, as it requires
      * to read the messages from storage.
      * This function takes into consideration batch messages
+     * and also Subscription filters. <br/>
+     * See also: {@link #analyzeSubscriptionBacklogAsync(String, String, Optional, long)}
+     * @param topic
+     *            Topic name
+     * @param subscriptionName
+     *            the subscription
+     * @param startPosition
+     *           the position to start the scan from (empty means the last processed message)
+     * @param backlogScanMaxEntries
+     *           the maximum number of backlog entries the client will scan before terminating its loop
+     * @return an accurate analysis of the backlog
+     * @throws PulsarAdminException
+     *            Unexpected error
+     */
+    AnalyzeSubscriptionBacklogResult analyzeSubscriptionBacklog(String topic, String subscriptionName,
+                                                                Optional<MessageId> startPosition,
+                                                                long backlogScanMaxEntries) throws PulsarAdminException;
+
+    /**
+     * Analyze subscription backlog.
+     * This is a potentially expensive operation, as it requires
+     * to read the messages from storage.
+     * This function takes into consideration batch messages
      * and also Subscription filters.
      * @param topic
      *            Topic name
@@ -2228,12 +2251,56 @@ public interface Topics {
      * @param startPosition
      *           the position to start the scan from (empty means the last processed message)
      * @return an accurate analysis of the backlog
-     * @throws PulsarAdminException
-     *            Unexpected error
      */
     CompletableFuture<AnalyzeSubscriptionBacklogResult> analyzeSubscriptionBacklogAsync(String topic,
                                                                            String subscriptionName,
                                                                            Optional<MessageId> startPosition);
+
+    /**
+     * Analyze subscription backlog.
+     * This is a potentially expensive operation, as it requires
+     * to read the messages from storage.
+     * This function takes into consideration batch messages
+     * and also Subscription filters.
+     *
+     *<p>
+     * What's the purpose of this overloaded method? <br/>
+     * There are broker side configurable maximum limits how many entries will be read and how long the scanning can
+     * take. The subscriptionBacklogScanMaxTimeMs (default 2 minutes) and subscriptionBacklogScanMaxEntries
+     * (default 10000) control this behavior. <br/>
+     * Increasing these settings is possible. However, it's possible that the HTTP request times out (also idle timeout
+     * in NAT/firewall etc.) before the command completes so increasing the limits might not be useful beyond a few
+     * minutes.
+     *<p/>
+     *
+     *<p>
+     * How does this method work? <br/>
+     * 1. Add a new parameter backlogScanMaxEntries in client side method to control the client-side loop termination
+     *    condition. <br/>
+     * 2. If subscriptionBacklogScanMaxEntries(server side) >= backlogScanMaxEntries(client side), then
+     *    backlogScanMaxEntries parameter will take no effect. <br/>
+     * 3. If subscriptionBacklogScanMaxEntries < backlogScanMaxEntries, the client will call analyze-backlog method in
+     *    a loop until server return ScanOutcome.COMPLETED or the total entries exceeds backlogScanMaxEntries. <br/>
+     * 4. This means that backlogScanMaxEntries cannot be used to precisely control the number of entries scanned by
+     *    the server, it only serves to determine when the loop should terminate. <br/>
+     * 5. With this method, the server can reduce the values of the two parameters subscriptionBacklogScanMaxTimeMs and
+     *    subscriptionBacklogScanMaxEntries, and then retrieve the desired number of backlog entries through
+     *    client-side looping.
+     *<p/>
+     * @param topic
+     *            Topic name
+     * @param subscriptionName
+     *            the subscription
+     * @param startPosition
+     *           the position to start the scan from (empty means the last processed message)
+     * @param backlogScanMaxEntries
+     *           the maximum number of backlog entries the client will scan before terminating its loop
+     * @return an accurate analysis of the backlog
+     */
+    CompletableFuture<AnalyzeSubscriptionBacklogResult> analyzeSubscriptionBacklogAsync(String topic,
+                                                                            String subscriptionName,
+                                                                            Optional<MessageId> startPosition,
+                                                                            long backlogScanMaxEntries);
 
     /**
      * Get backlog size by a message ID.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -2253,13 +2253,13 @@ public interface Topics {
      *            the subscription
      * @param startPosition
      *           the position to start the scan from (empty means the last processed message)
-     * @param continuePredicate
-     *           the predicate to determine whether to continue the loop
+     * @param terminatePredicate
+     *           the predicate to determine whether to terminate the loop
      * @return an accurate analysis of the backlog
      */
     AnalyzeSubscriptionBacklogResult analyzeSubscriptionBacklog(String topic, String subscriptionName,
                                                         Optional<MessageId> startPosition,
-                                                        Predicate<AnalyzeSubscriptionBacklogResult> continuePredicate)
+                                                        Predicate<AnalyzeSubscriptionBacklogResult> terminatePredicate)
             throws PulsarAdminException;
 
     /**
@@ -2333,7 +2333,7 @@ public interface Topics {
      * This function takes into consideration batch messages
      * and also Subscription filters. <br/>
      * See also: {@link #analyzeSubscriptionBacklogAsync(String, String, Optional, long)} <br/>
-     * User can control the loop termination condition by continuePredicate.
+     * User can control the loop termination condition by terminatePredicate.
      *
      * @param topic
      *            Topic name
@@ -2341,13 +2341,13 @@ public interface Topics {
      *            the subscription
      * @param startPosition
      *           the position to start the scan from (empty means the last processed message)
-     * @param continuePredicate
-     *           the predicate to determine whether to continue the loop
+     * @param terminatePredicate
+     *           the predicate to determine whether to terminate the loop
      * @return an accurate analysis of the backlog
      */
     CompletableFuture<AnalyzeSubscriptionBacklogResult> analyzeSubscriptionBacklogAsync(String topic,
                                                         String subscriptionName, Optional<MessageId> startPosition,
-                                                        Predicate<AnalyzeSubscriptionBacklogResult> continuePredicate);
+                                                        Predicate<AnalyzeSubscriptionBacklogResult> terminatePredicate);
 
     /**
      * Get backlog size by a message ID.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -2271,7 +2271,7 @@ public interface Topics {
      * Increasing these settings is possible. However, it's possible that the HTTP request times out (also idle timeout
      * in NAT/firewall etc.) before the command completes so increasing the limits might not be useful beyond a few
      * minutes.
-     *<p/>
+     *</p>
      *
      *<p>
      * How does this method work? <br/>
@@ -2286,7 +2286,7 @@ public interface Topics {
      * 5. With this method, the server can reduce the values of the two parameters subscriptionBacklogScanMaxTimeMs and
      *    subscriptionBacklogScanMaxEntries, so user can retrieve the desired number of backlog entries through
      *    client-side looping.
-     *<p/>
+     *</p>
      * @param topic
      *            Topic name
      * @param subscriptionName

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAllowedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
@@ -2243,6 +2244,29 @@ public interface Topics {
      * This is a potentially expensive operation, as it requires
      * to read the messages from storage.
      * This function takes into consideration batch messages
+     * and also Subscription filters. <br/>
+     * See also: {@link #analyzeSubscriptionBacklogAsync(String, String, Optional, Predicate)} <br/>
+     *
+     * @param topic
+     *            Topic name
+     * @param subscriptionName
+     *            the subscription
+     * @param startPosition
+     *           the position to start the scan from (empty means the last processed message)
+     * @param continuePredicate
+     *           the predicate to determine whether to continue the loop
+     * @return an accurate analysis of the backlog
+     */
+    AnalyzeSubscriptionBacklogResult analyzeSubscriptionBacklog(String topic, String subscriptionName,
+                                                        Optional<MessageId> startPosition,
+                                                        Predicate<AnalyzeSubscriptionBacklogResult> continuePredicate)
+            throws PulsarAdminException;
+
+    /**
+     * Analyze subscription backlog.
+     * This is a potentially expensive operation, as it requires
+     * to read the messages from storage.
+     * This function takes into consideration batch messages
      * and also Subscription filters.
      * @param topic
      *            Topic name
@@ -2301,6 +2325,29 @@ public interface Topics {
                                                                             String subscriptionName,
                                                                             Optional<MessageId> startPosition,
                                                                             long backlogScanMaxEntries);
+
+    /**
+     * Analyze subscription backlog.
+     * This is a potentially expensive operation, as it requires
+     * to read the messages from storage.
+     * This function takes into consideration batch messages
+     * and also Subscription filters. <br/>
+     * See also: {@link #analyzeSubscriptionBacklogAsync(String, String, Optional, long)} <br/>
+     * User can control the loop termination condition by continuePredicate.
+     *
+     * @param topic
+     *            Topic name
+     * @param subscriptionName
+     *            the subscription
+     * @param startPosition
+     *           the position to start the scan from (empty means the last processed message)
+     * @param continuePredicate
+     *           the predicate to determine whether to continue the loop
+     * @return an accurate analysis of the backlog
+     */
+    CompletableFuture<AnalyzeSubscriptionBacklogResult> analyzeSubscriptionBacklogAsync(String topic,
+                                                        String subscriptionName, Optional<MessageId> startPosition,
+                                                        Predicate<AnalyzeSubscriptionBacklogResult> continuePredicate);
 
     /**
      * Get backlog size by a message ID.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -2284,7 +2284,7 @@ public interface Topics {
      * 4. This means that backlogScanMaxEntries cannot be used to precisely control the number of entries scanned by
      *    the server, it only serves to determine when the loop should terminate. <br/>
      * 5. With this method, the server can reduce the values of the two parameters subscriptionBacklogScanMaxTimeMs and
-     *    subscriptionBacklogScanMaxEntries, and then retrieve the desired number of backlog entries through
+     *    subscriptionBacklogScanMaxEntries, so user can retrieve the desired number of backlog entries through
      *    client-side looping.
      *<p/>
      * @param topic

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1633,10 +1633,11 @@ public class TopicsImpl extends BaseResource implements Topics {
 
                 // To avoid infinite loops, we ensure the entry count is incremented after each loop.
                 if (currentResult.getEntries() <= 0) {
-                    log.warn("[{}][{}] Scanned total entry count is null, abort analyze backlog, start position is: {}",
-                            topic, subscriptionName, startPositionRef.get());
+                    log.warn("[{}][{}] Scanned total entry count is zero or negative, abort analyze backlog, start "
+                            + "position is: {}", topic, subscriptionName, startPositionRef.get());
                     future.completeExceptionally(
                             new PulsarAdminException("Incorrect total entry count returned from server"));
+                    return;
                 }
 
                 // In analyze-backlog, lastMessageId is null only when: total entries is 0,
@@ -1646,6 +1647,7 @@ public class TopicsImpl extends BaseResource implements Topics {
                             topic, subscriptionName, startPositionRef.get());
                     future.completeExceptionally(
                             new PulsarAdminException("Incorrect last message id returned from server"));
+                    return;
                 }
 
                 String[] messageIdSplits = mergedResult.getLastMessageId().split(":");
@@ -1684,7 +1686,7 @@ public class TopicsImpl extends BaseResource implements Topics {
                 current.getFilterRescheduledMessages() + previous.getFilterRescheduledMessages());
 
         mergedRes.setAborted(current.isAborted());
-        mergedRes.setFirstMessageId(current.getFirstMessageId());
+        mergedRes.setFirstMessageId(previous.getFirstMessageId());
         mergedRes.setLastMessageId(current.getLastMessageId());
 
         return mergedRes;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1577,9 +1577,9 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public AnalyzeSubscriptionBacklogResult analyzeSubscriptionBacklog(String topic, String subscriptionName,
                                                        Optional<MessageId> startPosition,
-                                                       Predicate<AnalyzeSubscriptionBacklogResult> continuePredicate)
+                                                       Predicate<AnalyzeSubscriptionBacklogResult> terminatePredicate)
             throws PulsarAdminException {
-        return sync(() -> analyzeSubscriptionBacklogAsync(topic, subscriptionName, startPosition, continuePredicate));
+        return sync(() -> analyzeSubscriptionBacklogAsync(topic, subscriptionName, startPosition, terminatePredicate));
     }
 
     @Override
@@ -1625,7 +1625,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<AnalyzeSubscriptionBacklogResult> analyzeSubscriptionBacklogAsync(String topic,
                                                        String subscriptionName, Optional<MessageId> startPosition,
-                                                       Predicate<AnalyzeSubscriptionBacklogResult> continuePredicate) {
+                                                       Predicate<AnalyzeSubscriptionBacklogResult> terminatePredicate) {
         final CompletableFuture<AnalyzeSubscriptionBacklogResult> future = new CompletableFuture<>();
         AtomicReference<AnalyzeSubscriptionBacklogResult> resultRef = new AtomicReference<>();
         int partitionIndex = TopicName.get(topic).getPartitionIndex();
@@ -1643,7 +1643,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
                 AnalyzeSubscriptionBacklogResult mergedResult = mergeBacklogResults(currentResult, resultRef.get());
                 resultRef.set(mergedResult);
-                if (!mergedResult.isAborted() || continuePredicate.test(mergedResult)) {
+                if (!mergedResult.isAborted() || terminatePredicate.test(mergedResult)) {
                     future.complete(mergedResult);
                     return;
                 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1625,7 +1625,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
                 AnalyzeSubscriptionBacklogResult mergedResult = mergeBacklogResults(currentResult, resultRef.get());
                 resultRef.set(mergedResult);
-                if (mergedResult.isAborted() || mergedResult.getEntries() >= backlogScanMaxEntries) {
+                if (!mergedResult.isAborted() || mergedResult.getEntries() >= backlogScanMaxEntries) {
                     future.complete(mergedResult);
                     return;
                 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -1631,6 +1631,14 @@ public class TopicsImpl extends BaseResource implements Topics {
                     return;
                 }
 
+                // To avoid infinite loops, we ensure the entry count is incremented after each loop.
+                if (currentResult.getEntries() <= 0) {
+                    log.warn("[{}][{}] Scanned total entry count is null, abort analyze backlog, start position is: {}",
+                            topic, subscriptionName, startPositionRef.get());
+                    future.completeExceptionally(
+                            new PulsarAdminException("Incorrect total entry count returned from server"));
+                }
+
                 // In analyze-backlog, lastMessageId is null only when: total entries is 0,
                 // with false aborted flag returned.
                 if (StringUtils.isBlank(mergedResult.getLastMessageId())) {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -34,6 +34,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.ws.rs.client.Entity;
@@ -1561,6 +1564,15 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
+    public AnalyzeSubscriptionBacklogResult analyzeSubscriptionBacklog(String topic, String subscriptionName,
+                                                                       Optional<MessageId> startPosition,
+                                                                       long backlogScanMaxEntries)
+            throws PulsarAdminException {
+        return sync(
+                () -> analyzeSubscriptionBacklogAsync(topic, subscriptionName, startPosition, backlogScanMaxEntries));
+    }
+
+    @Override
     public CompletableFuture<AnalyzeSubscriptionBacklogResult> analyzeSubscriptionBacklogAsync(String topic,
                                                                                 String subscriptionName,
                                                                                 Optional<MessageId> startPosition) {
@@ -1589,6 +1601,75 @@ public class TopicsImpl extends BaseResource implements Topics {
             }
         });
         return future;
+    }
+
+    @Override
+    public CompletableFuture<AnalyzeSubscriptionBacklogResult> analyzeSubscriptionBacklogAsync(String topic,
+                                                                               String subscriptionName,
+                                                                               Optional<MessageId> startPosition,
+                                                                               long backlogScanMaxEntries) {
+        final CompletableFuture<AnalyzeSubscriptionBacklogResult> future = new CompletableFuture<>();
+        AtomicReference<AnalyzeSubscriptionBacklogResult> resultRef = new AtomicReference<>();
+        int partitionIndex = TopicName.get(topic).getPartitionIndex();
+        AtomicReference<Optional<MessageId>> startPositionRef = new AtomicReference<>(startPosition);
+
+        Supplier<CompletableFuture<AnalyzeSubscriptionBacklogResult>> resultSupplier =
+                () -> analyzeSubscriptionBacklogAsync(topic, subscriptionName, startPositionRef.get());
+        BiConsumer<AnalyzeSubscriptionBacklogResult, Throwable> completeAction = new BiConsumer<>() {
+            @Override
+            public void accept(AnalyzeSubscriptionBacklogResult currentResult, Throwable throwable) {
+                if (throwable != null) {
+                    future.completeExceptionally(throwable);
+                    return;
+                }
+
+                AnalyzeSubscriptionBacklogResult mergedResult = mergeBacklogResults(currentResult, resultRef.get());
+                resultRef.set(mergedResult);
+                if (mergedResult.isAborted() || mergedResult.getEntries() >= backlogScanMaxEntries) {
+                    future.complete(mergedResult);
+                    return;
+                }
+
+                String[] messageIdSplits = mergedResult.getLastMessageId().split(":");
+                MessageIdImpl nextScanMessageId =
+                        new MessageIdImpl(Long.parseLong(messageIdSplits[0]), Long.parseLong(messageIdSplits[1]) + 1,
+                                partitionIndex);
+                startPositionRef.set(Optional.of(nextScanMessageId));
+
+                resultSupplier.get().whenComplete(this);
+            }
+        };
+
+        resultSupplier.get().whenComplete(completeAction);
+        return future;
+    }
+
+    private AnalyzeSubscriptionBacklogResult mergeBacklogResults(AnalyzeSubscriptionBacklogResult current,
+                                                                 AnalyzeSubscriptionBacklogResult previous) {
+        if (previous == null) {
+            return current;
+        }
+
+        AnalyzeSubscriptionBacklogResult mergedRes = new AnalyzeSubscriptionBacklogResult();
+        mergedRes.setEntries(current.getEntries() + previous.getEntries());
+        mergedRes.setMessages(current.getMessages() + previous.getMessages());
+        mergedRes.setMarkerMessages(current.getMarkerMessages() + previous.getMarkerMessages());
+
+        mergedRes.setFilterAcceptedEntries(current.getFilterAcceptedEntries() + previous.getFilterAcceptedEntries());
+        mergedRes.setFilterRejectedEntries(current.getFilterRejectedEntries() + previous.getFilterRejectedEntries());
+        mergedRes.setFilterRescheduledEntries(
+                current.getFilterRescheduledEntries() + previous.getFilterRescheduledEntries());
+
+        mergedRes.setFilterAcceptedMessages(current.getFilterAcceptedMessages() + previous.getFilterAcceptedMessages());
+        mergedRes.setFilterRejectedMessages(current.getFilterRejectedMessages() + previous.getFilterRejectedMessages());
+        mergedRes.setFilterRescheduledMessages(
+                current.getFilterRescheduledMessages() + previous.getFilterRescheduledMessages());
+
+        mergedRes.setAborted(current.isAborted());
+        mergedRes.setFirstMessageId(current.getFirstMessageId());
+        mergedRes.setLastMessageId(current.getLastMessageId());
+
+        return mergedRes;
     }
 
     @Override


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar/issues/25083

### Motivation

Use client-side looping instead of increasing broker settings to avoid potential HTTP call timeout in analyze-backlog method of Topics.

### Modifications

Add client-side looping, add test.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
