### PR TITLE
[fix][test] Wait for txn.abort() to complete to avoid AdminApiTransactionTest.testAnalyzeSubscriptionBacklogWithTransactionMarker() flaky test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -1091,7 +1091,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
             Transaction txn = pulsarClient.newTransaction().build().get();
             MessageId messageId = producer.newMessage(txn).value("aborted-msg" + i).send();
             abortedMsgIds.add(messageId);
-            txn.abort();
+            txn.abort().get();
         }
         backlogResult = admin.topics().analyzeSubscriptionBacklog(topic, transactionSubName, Optional.empty());
         assertEquals(backlogResult.getMessages(), numMessages * 2);


### PR DESCRIPTION
### Motivation

Fix `AdminApiTransactionTest.testAnalyzeSubscriptionBacklogWithTransactionMarker()` flaky test.

Example failure:

```
  Error:  org.apache.pulsar.broker.admin.v3.AdminApiTransactionTest.testAnalyzeSubscriptionBacklogWithTransactionMarker
  [INFO]   Run 1: PASS
  Error:    Run 2: AdminApiTransactionTest.testAnalyzeSubscriptionBacklogWithTransactionMarker:1098 expected [20] but found [19]
```

https://github.com/oneby-wang/pulsar/actions/runs/20709883704/job/59448327174?pr=22

### Modifications

 Wait for `txn.abort()` to complete to avoid flaky test.
 
I checked two other test methods for `topics.peekMessages()` that do not use `txn.abort().get()`; I ran these tests a lot of times locally and found them are not flaky. 

https://github.com/apache/pulsar/blob/bf98773a2d3f6ecf73560fe4e682ce058dcfde61/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java#L970-L979

https://github.com/apache/pulsar/blob/bf98773a2d3f6ecf73560fe4e682ce058dcfde61/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java#L1019-L1027

I read the source code and found that `topics.peekMessages()` returns only when the specified `numMessages` have been retrieved.

https://github.com/apache/pulsar/blob/bf98773a2d3f6ecf73560fe4e682ce058dcfde61/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java#L921-L927

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 