### PR TITLE
[fix][test] Use AtomicBoolean.compareAndSet() to guarantee atomicity in testDoIndividualBatchAckNeverAffectIsDuplicate() method

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AcknowledgementsGroupingTrackerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AcknowledgementsGroupingTrackerTest.java
@@ -437,7 +437,7 @@ public class AcknowledgementsGroupingTrackerTest {
             Thread isDuplicateThread = new Thread(() -> {
                 for (int j = 0; j < loops; j++) {
                     boolean duplicate = tracker.isDuplicate(batchMessageId1);
-                    assertResult.set(assertResult.get() || duplicate);
+                    assertResult.compareAndSet(false, duplicate);
                 }
             }, "isDuplicate-thread-" + i);
             isDuplicateThread.start();


### PR DESCRIPTION
### Motivation

See https://github.com/apache/pulsar/pull/25208#discussion_r2768955002

The `assertResult.set(assertResult.get() || duplicate)` operation can't guarantee atomicity. After being set to true, the value of `assertResult` may be overwritten to false again.

### Modifications

Use `assertResult.compareAndSet(false, duplicate)` to guarantee atomicity.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 