### PR TITLE
[fix][sec] Upgrade Jackson version to 2.18.6

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -249,17 +249,17 @@ The Apache Software License, Version 2.0
      - info.picocli-picocli-shell-jline3-4.7.5.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.9.1.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.17.2.jar
-     - com.fasterxml.jackson.core-jackson-core-2.17.2.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.17.2.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.17.2.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.17.2.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.17.2.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.17.2.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.17.2.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.17.2.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.17.2.jar
-     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.17.2.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.18.6.jar
+     - com.fasterxml.jackson.core-jackson-core-2.18.6.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.18.6.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.18.6.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.18.6.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.18.6.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.18.6.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.18.6.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.18.6.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.18.6.jar
+     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.18.6.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.2.3.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Fastutil -- it.unimi.dsi-fastutil-8.5.16.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -313,17 +313,17 @@ The Apache Software License, Version 2.0
      - picocli-4.7.5.jar
      - picocli-shell-jline3-4.7.5.jar
  * Jackson
-     - jackson-annotations-2.17.2.jar
-     - jackson-core-2.17.2.jar
-     - jackson-databind-2.17.2.jar
-     - jackson-dataformat-yaml-2.17.2.jar
-     - jackson-jaxrs-base-2.17.2.jar
-     - jackson-jaxrs-json-provider-2.17.2.jar
-     - jackson-module-jaxb-annotations-2.17.2.jar
-     - jackson-module-jsonSchema-2.17.2.jar
-     - jackson-datatype-jdk8-2.17.2.jar
-     - jackson-datatype-jsr310-2.17.2.jar
-     - jackson-module-parameter-names-2.17.2.jar
+     - jackson-annotations-2.18.6.jar
+     - jackson-core-2.18.6.jar
+     - jackson-databind-2.18.6.jar
+     - jackson-dataformat-yaml-2.18.6.jar
+     - jackson-jaxrs-base-2.18.6.jar
+     - jackson-jaxrs-json-provider-2.18.6.jar
+     - jackson-module-jaxb-annotations-2.18.6.jar
+     - jackson-module-jsonSchema-2.18.6.jar
+     - jackson-datatype-jdk8-2.18.6.jar
+     - jackson-datatype-jsr310-2.18.6.jar
+     - jackson-module-parameter-names-2.18.6.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.5.2.jar
  * Gson
     - gson-2.13.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1728,6 +1728,10 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@ flexible messaging model and an intuitive client API.</description>
     <bouncycastle.bcprov-ext-jdk18on.version>1.78.1</bouncycastle.bcprov-ext-jdk18on.version>
     <bouncycastle.bcpkix-fips.version>2.0.10</bouncycastle.bcpkix-fips.version>
     <bouncycastle.bc-fips.version>2.0.1</bouncycastle.bc-fips.version>
-    <jackson.version>2.17.2</jackson.version>
+    <jackson.version>2.18.6</jackson.version>
     <fastutil.version>8.5.16</fastutil.version>
     <jctools.version>4.0.5</jctools.version>
     <reflections.version>0.10.2</reflections.version>


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar/issues/25260

### Motivation

Jackson 2.17.x used in Pulsar is no longer maintained. Upgrade Jackson version to a LTS version.

### Modifications

Upgrade Jackson version to 2.18.6 and exclude `javax.xml.bind-jaxb-api` dependency.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 