### PR TITLE
[improve][admin] Add namespace migration state query in rest API

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -3355,6 +3355,12 @@ public abstract class NamespacesBase extends AdminResource {
                         .log("Successfully updated migration on namespace"));
     }
 
+    protected CompletableFuture<Boolean> internalGetMigrationAsync() {
+        return validateSuperUserAccessAsync()
+                .thenCompose(__ -> getLocalPolicies().getLocalPoliciesAsync(namespaceName))
+                .thenApply(policiesOpt -> policiesOpt.map(localPolicies -> localPolicies.migrated).orElse(false));
+    }
+
     protected Policies getDefaultPolicesIfNull(Policies policies) {
         if (policies == null) {
             policies = new Policies();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -3419,7 +3419,7 @@ public class Namespaces extends NamespacesBase {
 
     @POST
     @Path("/{tenant}/{namespace}/migration")
-    @ApiOperation(hidden = true, value = "Update migration for all topics in a namespace")
+    @ApiOperation(hidden = true, value = "Update the migration state for a namespace")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),
@@ -3437,6 +3437,31 @@ public class Namespaces extends NamespacesBase {
                             .attr("namespace", namespace)
                             .exception(ex)
                             .log("Failed to update migration");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    @GET
+    @Path("/{tenant}/{namespace}/migration")
+    @ApiOperation(hidden = true, value = "Get the migration state for a namespace",
+            response = Boolean.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist")})
+    public void getMigration(@Suspended AsyncResponse asyncResponse,
+                             @PathParam("tenant") String tenant,
+                             @PathParam("namespace") String namespace) {
+        validateNamespaceName(tenant, namespace);
+        internalGetMigrationAsync()
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(ex -> {
+                    log.error()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .exception(ex)
+                            .log("Failed to get migration");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -2312,25 +2312,25 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         admin.namespaces().createNamespace(namespace, Set.of(testLocalCluster));
 
         admin.namespaces().updateMigrationState(namespace, true);
-        assertTrue(admin.namespaces().getPolicies(namespace).migrated);
+        assertTrue(admin.namespaces().getMigrationState(namespace));
 
         String bookieAffinityGroupPrimary = "group1";
         admin.namespaces().setBookieAffinityGroup(namespace,
                 BookieAffinityGroupData.builder().bookkeeperAffinityGroupPrimary(bookieAffinityGroupPrimary).build());
         assertEquals(admin.namespaces().getBookieAffinityGroup(namespace).getBookkeeperAffinityGroupPrimary(),
                 bookieAffinityGroupPrimary);
-        assertTrue(admin.namespaces().getPolicies(namespace).migrated);
+        assertTrue(admin.namespaces().getMigrationState(namespace));
 
         String namespaceAntiAffinityGroup = "group2";
         admin.namespaces().setNamespaceAntiAffinityGroup(namespace, namespaceAntiAffinityGroup);
         assertEquals(admin.namespaces().getNamespaceAntiAffinityGroup(namespace), namespaceAntiAffinityGroup);
-        assertTrue(admin.namespaces().getPolicies(namespace).migrated);
+        assertTrue(admin.namespaces().getMigrationState(namespace));
 
         admin.namespaces().deleteBookieAffinityGroup(namespace);
-        assertTrue(admin.namespaces().getPolicies(namespace).migrated);
+        assertTrue(admin.namespaces().getMigrationState(namespace));
 
         admin.namespaces().deleteNamespaceAntiAffinityGroup(namespace);
-        assertTrue(admin.namespaces().getPolicies(namespace).migrated);
+        assertTrue(admin.namespaces().getMigrationState(namespace));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
@@ -364,9 +364,9 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
         assertEquals(bundlesData.getNumBundles(), conf.getDefaultNumberOfNamespaceBundles());
 
         // 4.assert namespace enable migration
-        Policies policiesResp = (Policies) asyncRequests(
-                response -> namespaces.getPolicies(response, testTenant, enableMigrationGroupNs));
-        assertEquals(policiesResp.migrated, enableMigrationReq);
+        Boolean migratedResp = (Boolean) asyncRequests(
+                response -> namespaces.getMigration(response, testTenant, enableMigrationGroupNs));
+        assertEquals(migratedResp, enableMigrationReq);
     }
 
     @Test
@@ -389,9 +389,9 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
         assertEquals(bundlesData, policiesReq.bundles);
 
         // 4.assert namespace enable migration
-        Policies policiesResp = (Policies) asyncRequests(
-                response -> namespaces.getPolicies(response, testTenant, enableMigrationGroupNs));
-        assertEquals(policiesResp.migrated, enableMigrationReq);
+        Boolean migratedResp = (Boolean) asyncRequests(
+                response -> namespaces.getMigration(response, testTenant, enableMigrationGroupNs));
+        assertEquals(migratedResp, enableMigrationReq);
     }
 
     @Test
@@ -508,12 +508,18 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
 
         // Enable migration
         asyncRequests(response -> namespaces.enableMigration(response, testTenant, enableMigrationGroupNs, true));
+        Boolean migratedResp = (Boolean) asyncRequests(
+                response -> namespaces.getMigration(response, testTenant, enableMigrationGroupNs));
+        assertTrue(migratedResp);
         Policies policiesResp = (Policies) asyncRequests(
                 response -> namespaces.getPolicies(response, testTenant, enableMigrationGroupNs));
         assertTrue(policiesResp.migrated);
 
         // Disable migration
         asyncRequests(response -> namespaces.enableMigration(response, testTenant, enableMigrationGroupNs, false));
+        migratedResp = (Boolean) asyncRequests(
+                response -> namespaces.getMigration(response, testTenant, enableMigrationGroupNs));
+        assertFalse(migratedResp);
         policiesResp = (Policies) asyncRequests(
                 response -> namespaces.getPolicies(response, testTenant, enableMigrationGroupNs));
         assertFalse(policiesResp.migrated);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
@@ -1134,7 +1134,7 @@ public class ClusterMigrationTest {
                 pulsar2.getBrokerServiceUrl(), pulsar2.getBrokerServiceUrlTls());
         admin1.clusters().updateClusterMigration("r1", isClusterMigrate, migratedUrl);
         admin1.namespaces().updateMigrationState(namespace, isNamespaceMigrate);
-        assertEquals(admin1.namespaces().getPolicies(namespace).migrated, isNamespaceMigrate);
+        assertEquals(admin1.namespaces().getMigrationState(namespace), isNamespaceMigrate);
         log.info("update cluster migration called");
 
         retryStrategically((test) -> {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -4725,9 +4725,7 @@ public interface Namespaces {
     CompletableFuture<Void> removeNamespaceEntryFiltersAsync(String namespace);
 
     /**
-     * Enable migration for all topics within a namespace.
-     * <p/>
-     * Migrate all topics of a namespace to new broker.
+     * Update the migration state for a namespace.
      * <p/>
      * Request example:
      *
@@ -4747,6 +4745,30 @@ public interface Namespaces {
      *             Unexpected error
      */
     void updateMigrationState(String namespace, boolean migrated) throws PulsarAdminException;
+
+    /**
+     * Get the migration state for a namespace.
+     *
+     * @param namespace
+     *            Namespace name
+     * @return whether the namespace is marked as migrated
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Namespace does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    boolean getMigrationState(String namespace) throws PulsarAdminException;
+
+    /**
+     * Get the migration state for a namespace asynchronously.
+     *
+     * @param namespace
+     *            Namespace name
+     * @return whether the namespace is marked as migrated
+     */
+    CompletableFuture<Boolean> getMigrationStateAsync(String namespace);
 
     /**
      * Set DispatcherPauseOnAckStatePersistent for a namespace asynchronously.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -1990,10 +1990,23 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
         sync(() -> updateMigrationStateAsync(namespace, migrated));
     }
 
+    @Override
+    public boolean getMigrationState(String namespace) throws PulsarAdminException {
+        return sync(() -> getMigrationStateAsync(namespace));
+    }
+
     public CompletableFuture<Void> updateMigrationStateAsync(String namespace, boolean migrated) {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "migration");
         return asyncPostRequest(path, Entity.entity(migrated, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> getMigrationStateAsync(String namespace) {
+        NamespaceName ns = NamespaceName.get(namespace);
+        WebTarget path = namespacePath(ns, "migration");
+        return asyncGetRequest(path, new FutureCallback<Boolean>() {
+        });
     }
 
     private WebTarget namespacePath(NamespaceName namespace, String... parts) {


### PR DESCRIPTION
### Motivation

The namespace migration API only supports updating the `migrated` flag, but there is no dedicated API to query the namespace migration state directly.

### Modifications

Add a namespace migration state query API in broker and admin client, and update the related tests to use the new API.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 