### PR TITLE
[fix][broker] Fix ManagedLedgerImpl.advanceCursorsIfNecessary() method may lose non-durable cursor properties in race condition

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3281,7 +3281,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     && highestPositionToDelete.compareTo(cursor.getManagedLedger()
                     .getLastConfirmedEntry()) <= 0 && !(!cursor.isDurable() && cursor instanceof NonDurableCursorImpl
                     && ((NonDurableCursorImpl) cursor).isReadCompacted())) {
-                cursor.asyncMarkDelete(highestPositionToDelete, cursor.getProperties(), new MarkDeleteCallback() {
+                cursor.asyncMarkDelete(highestPositionToDelete, null, new MarkDeleteCallback() {
                     @Override
                     public void markDeleteComplete(Object ctx) {
                     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -5411,7 +5411,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         assertEquals(cursor.getProperties(), expectedProperties);
     }
 
-    @Test
+    @Test(invocationCount = 100)
     @SuppressWarnings("unchecked")
     public void testAdvanceCursorsIfNecessaryNeverLoseMarkDeleteProperties() throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();
@@ -5474,6 +5474,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         nonDurableCursor.markDelete(pos2, properties);
 
         advanceCursorsMarkDeleteCompletedLatch.await();
+        assertEquals(nonDurableCursor.getMarkDeletedPosition(), pos2);
         assertEquals(nonDurableCursor.getProperties(), properties);
     }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -5438,6 +5438,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         doAnswer(invocation -> {
             Map<String, Long> invocationProperties = invocation.getArgument(1);
+            // Pause the advanceCursorsIfNecessary mark-delete so the nonDurableCursor markDelete() can complete first.
             if (invocationProperties == null || invocationProperties.isEmpty()) {
                 advanceCursorsMarkDeleteEnteredLatch.countDown();
                 assertTrue(nonDurableCursorsMarkDeleteCompletedLatch.await(5, TimeUnit.SECONDS));

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -5411,7 +5411,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         assertEquals(cursor.getProperties(), expectedProperties);
     }
 
-    @Test(invocationCount = 100)
+    @Test
     @SuppressWarnings("unchecked")
     public void testAdvanceCursorsIfNecessaryNeverLoseMarkDeleteProperties() throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -5432,24 +5432,20 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         ledger.getCursors().removeCursor(realNonDurableCursor.getName());
         ledger.getCursors().add(nonDurableCursor, null);
 
+        CountDownLatch advanceCursorsMarkDeleteEnteredLatch = new CountDownLatch(1);
+        CountDownLatch nonDurableCursorsMarkDeleteCompletedLatch = new CountDownLatch(1);
         CountDownLatch advanceCursorsMarkDeleteCompletedLatch = new CountDownLatch(1);
-        CountDownLatch nonDurableCursorMarkDeleteCompletedLatch = new CountDownLatch(1);
 
         doAnswer(invocation -> {
             Map<String, Long> invocationProperties = invocation.getArgument(1);
 
-            // Let the user-triggered nonDurableCursor.markDelete() with properties complete first.
             if (invocationProperties != null && invocationProperties.size() == 1) {
-                try {
-                    return invocation.callRealMethod();
-                } finally {
-                    nonDurableCursorMarkDeleteCompletedLatch.countDown();
-                }
+                return invocation.callRealMethod();
             }
 
-            // Then let the trim-triggered advanceCursorsIfNecessary() mark-delete proceed.
             if (invocationProperties == null || invocationProperties.isEmpty()) {
-                nonDurableCursorMarkDeleteCompletedLatch.await();
+                advanceCursorsMarkDeleteEnteredLatch.countDown();
+                assertTrue(nonDurableCursorsMarkDeleteCompletedLatch.await(5, TimeUnit.SECONDS));
                 try {
                     return invocation.callRealMethod();
                 } finally {
@@ -5467,13 +5463,15 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         // Mark-delete the durable cursor to trigger trimming, which advances non-durable cursors.
         durableCursor.markDelete(pos2);
+        assertTrue(advanceCursorsMarkDeleteEnteredLatch.await(5, TimeUnit.SECONDS));
 
         String propertyKey = "test-property";
         Map<String, Long> properties = new HashMap<>();
         properties.put(propertyKey, 1L);
         nonDurableCursor.markDelete(pos2, properties);
+        nonDurableCursorsMarkDeleteCompletedLatch.countDown();
 
-        advanceCursorsMarkDeleteCompletedLatch.await();
+        assertTrue(advanceCursorsMarkDeleteCompletedLatch.await(5, TimeUnit.SECONDS));
         assertEquals(nonDurableCursor.getMarkDeletedPosition(), pos2);
         assertEquals(nonDurableCursor.getProperties(), properties);
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -5438,11 +5438,6 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         doAnswer(invocation -> {
             Map<String, Long> invocationProperties = invocation.getArgument(1);
-
-            if (invocationProperties != null && invocationProperties.size() == 1) {
-                return invocation.callRealMethod();
-            }
-
             if (invocationProperties == null || invocationProperties.isEmpty()) {
                 advanceCursorsMarkDeleteEnteredLatch.countDown();
                 assertTrue(nonDurableCursorsMarkDeleteCompletedLatch.await(5, TimeUnit.SECONDS));

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -5408,5 +5409,71 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         // Verify properties are preserved after cursor reset
         assertEquals(cursor.getProperties(), expectedProperties);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAdvanceCursorsIfNecessaryNeverLoseMarkDeleteProperties() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(1);
+        config.setRetentionTime(0, TimeUnit.SECONDS);
+        config.setRetentionSizeInMB(0);
+
+        @Cleanup
+        ManagedLedgerImpl ledger =
+                (ManagedLedgerImpl) factory.open("testAdvanceCursorsIfNecessaryNeverLoseMarkDeleteProperties", config);
+        @Cleanup
+        ManagedCursorImpl durableCursor = (ManagedCursorImpl) ledger.openCursor("durableCursor1");
+        @Cleanup
+        NonDurableCursorImpl realNonDurableCursor =
+                (NonDurableCursorImpl) ledger.newNonDurableCursor(PositionFactory.EARLIEST);
+        NonDurableCursorImpl nonDurableCursor = spy(realNonDurableCursor);
+
+        ledger.getCursors().removeCursor(realNonDurableCursor.getName());
+        ledger.getCursors().add(nonDurableCursor, null);
+
+        CountDownLatch advanceCursorsMarkDeleteCompletedLatch = new CountDownLatch(1);
+        CountDownLatch nonDurableCursorMarkDeleteCompletedLatch = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            Map<String, Long> invocationProperties = invocation.getArgument(1);
+
+            // Let the user-triggered nonDurableCursor.markDelete() with properties complete first.
+            if (invocationProperties != null && invocationProperties.size() == 1) {
+                try {
+                    return invocation.callRealMethod();
+                } finally {
+                    nonDurableCursorMarkDeleteCompletedLatch.countDown();
+                }
+            }
+
+            // Then let the trim-triggered advanceCursorsIfNecessary() mark-delete proceed.
+            if (invocationProperties == null || invocationProperties.isEmpty()) {
+                nonDurableCursorMarkDeleteCompletedLatch.await();
+                try {
+                    return invocation.callRealMethod();
+                } finally {
+                    advanceCursorsMarkDeleteCompletedLatch.countDown();
+                }
+            }
+
+            return invocation.callRealMethod();
+        }).when(nonDurableCursor)
+                .internalAsyncMarkDelete(any(Position.class), nullable(Map.class), any(MarkDeleteCallback.class),
+                        nullable(Object.class), nullable(Runnable.class));
+
+        ledger.addEntry("entry-1".getBytes(Encoding));
+        Position pos2 = ledger.addEntry("entry-2".getBytes(Encoding));
+
+        // Mark-delete the durable cursor to trigger trimming, which advances non-durable cursors.
+        durableCursor.markDelete(pos2);
+
+        String propertyKey = "test-property";
+        Map<String, Long> properties = new HashMap<>();
+        properties.put(propertyKey, 1L);
+        nonDurableCursor.markDelete(pos2, properties);
+
+        advanceCursorsMarkDeleteCompletedLatch.await();
+        assertEquals(nonDurableCursor.getProperties(), properties);
     }
 }


### PR DESCRIPTION
### Motivation

This is a follow-up to apache/pulsar#25165 for the same class of race condition, covering `ManagedLedgerImpl.advanceCursorsIfNecessary()` and non-durable cursor properties.

`ManagedLedgerImpl.advanceCursorsIfNecessary()` method may lose non-durable cursor mark-delete properties in a race condition.

When `advanceCursorsIfNecessary()` advances a non-durable cursor while another `markDelete()` call with properties is in progress, passing the cursor current properties can capture stale properties and later overwrite the user-provided mark-delete properties.

### Modifications

1. Add `testAdvanceCursorsIfNecessaryNeverLoseProperties()` test to reproduce the issue.
2. Pass `null` to `asyncMarkDelete()` method properties param in `advanceCursorsIfNecessary()` method, so the cursor uses the latest properties when the mark-delete is applied.
3. Run test to verify the code change.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->