### PR TITLE
[fix][test] Fix flaky ResendRequestTest.testSharedSingleAckedPartitionedTopic() test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
@@ -508,13 +508,13 @@ public class ResendRequestTest extends SharedPulsarBaseTest {
         // 3. Create consumer
         @Cleanup
         Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
-                .receiverQueueSize(7).subscriptionType(SubscriptionType.Shared).subscriptionInitialPosition(
+                .receiverQueueSize(2).subscriptionType(SubscriptionType.Shared).subscriptionInitialPosition(
                         SubscriptionInitialPosition.Earliest).subscribe();
 
         @Cleanup
         PulsarClient newPulsarClient = newPulsarClient();
         Consumer<byte[]> consumer2 = newPulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
-                .receiverQueueSize(7).subscriptionType(SubscriptionType.Shared).subscriptionInitialPosition(
+                .receiverQueueSize(2).subscriptionType(SubscriptionType.Shared).subscriptionInitialPosition(
                         SubscriptionInitialPosition.Earliest).subscribe();
 
         // 4. Receive messages

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
@@ -492,11 +492,13 @@ public class ResendRequestTest extends SharedPulsarBaseTest {
         Random rn = new Random();
 
         // 1. producer connect
+        @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
             .enableBatching(false)
             .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
 
         // 2. Create consumer
+        @Cleanup
         Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
                 .receiverQueueSize(7).subscriptionType(SubscriptionType.Shared).subscribe();
 
@@ -513,16 +515,16 @@ public class ResendRequestTest extends SharedPulsarBaseTest {
         }
 
         // 4. Receive messages
-        // Use timeouts on the initial receives — with a Shared subscription the broker may
-        // dispatch all messages to a single consumer (receiverQueueSize is larger than the
-        // number of messages per partition), and a blocking receive() would hang.
-        Message<byte[]> message1 = consumer1.receive(5000, TimeUnit.MILLISECONDS);
-        Message<byte[]> message2 = consumer2.receive(5000, TimeUnit.MILLISECONDS);
         int messageCount1 = 0;
         int messageCount2 = 0;
         int ackCount1 = 0;
         int ackCount2 = 0;
-        do {
+        while (true) {
+            Message<byte[]> message1 = consumer1.receive(500, TimeUnit.MILLISECONDS);
+            Message<byte[]> message2 = consumer2.receive(500, TimeUnit.MILLISECONDS);
+            if (message1 == null && message2 == null) {
+                break;
+            }
             if (message1 != null) {
                 log.info().attr("data", new String(message1.getData())).log("Consumer1 received");
                 messageCount1 += 1;
@@ -541,9 +543,7 @@ public class ResendRequestTest extends SharedPulsarBaseTest {
                     ackCount2 += 1;
                 }
             }
-            message1 = consumer1.receive(500, TimeUnit.MILLISECONDS);
-            message2 = consumer2.receive(500, TimeUnit.MILLISECONDS);
-        } while (message1 != null || message2 != null);
+        }
         log.info().attr("messageCount1", messageCount1).log("messageCount1");
         log.info().attr("messageCount2", messageCount2).log("messageCount2");
         log.info().attr("ackCount1", ackCount1).log("ackCount1");
@@ -558,10 +558,13 @@ public class ResendRequestTest extends SharedPulsarBaseTest {
         }
 
         // 6. Check if Messages redelivered again
-        message1 = consumer1.receive(5000, TimeUnit.MILLISECONDS);
-        message2 = consumer2.receive(5000, TimeUnit.MILLISECONDS);
         messageCount1 = 0;
-        do {
+        while (true) {
+            Message<byte[]> message1 = consumer1.receive(500, TimeUnit.MILLISECONDS);
+            Message<byte[]> message2 = consumer2.receive(500, TimeUnit.MILLISECONDS);
+            if (message1 == null && message2 == null) {
+                break;
+            }
             if (message1 != null) {
                 log.info().attr("data", new String(message1.getData())).log("Consumer1 received");
                 messageCount1 += 1;
@@ -570,10 +573,7 @@ public class ResendRequestTest extends SharedPulsarBaseTest {
                 log.info().attr("data", new String(message2.getData())).log("Consumer2 received");
                 messageCount2 += 1;
             }
-            message1 = consumer1.receive(1000, TimeUnit.MILLISECONDS);
-            message2 = consumer2.receive(1000, TimeUnit.MILLISECONDS);
-        } while (message1 != null || message2 != null);
-
+        }
         log.info().attr("messageCount1", messageCount1).log("messageCount1");
         log.info().attr("messageCount2", messageCount2).log("messageCount2");
         log.info().attr("ackCount1", ackCount1).log("ackCount1");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerBase;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
@@ -494,25 +495,27 @@ public class ResendRequestTest extends SharedPulsarBaseTest {
         // 1. producer connect
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
-            .enableBatching(false)
-            .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
 
-        // 2. Create consumer
-        @Cleanup
-        Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
-                .receiverQueueSize(7).subscriptionType(SubscriptionType.Shared).subscribe();
-
-        @Cleanup
-        PulsarClient newPulsarClient = newPulsarClient();
-        Consumer<byte[]> consumer2 = newPulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
-                .receiverQueueSize(7).subscriptionType(SubscriptionType.Shared).subscribe();
-
-        // 3. producer publish messages
+        // 2. producer publish messages
         for (int i = 0; i < totalMessages; i++) {
             String message = messagePredicate + i;
             log.info().attr("message", message).log("Message produced");
             producer.send(message.getBytes());
         }
+
+        // 3. Create consumer
+        @Cleanup
+        Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(7).subscriptionType(SubscriptionType.Shared).subscriptionInitialPosition(
+                        SubscriptionInitialPosition.Earliest).subscribe();
+
+        @Cleanup
+        PulsarClient newPulsarClient = newPulsarClient();
+        Consumer<byte[]> consumer2 = newPulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(7).subscriptionType(SubscriptionType.Shared).subscriptionInitialPosition(
+                        SubscriptionInitialPosition.Earliest).subscribe();
 
         // 4. Receive messages
         int messageCount1 = 0;


### PR DESCRIPTION
Fixes apache/pulsar#25815

This test has already been fixed by [apache/pulsar@55e6022](https://github.com/apache/pulsar/commit/55e6022f2a12cd775f90e09a8756feb02dd2b1b0). This PR refines the test implementation.

### Motivation

`ResendRequestTest.testSharedSingleAckedPartitionedTopic` is flaky because it assumes that both consumers on a shared subscription will receive at least one message.

The test used blocking `receive()` calls for both consumers before entering the receive loop. If the first consumer receives messages but the second consumer does not, the test can block until the TestNG timeout.

This can happen even when producer batching is disabled. `enableBatching=false` only means the producer will not combine multiple user messages into one batch message or one batch entry. The broker dispatcher can still read multiple entries from the managed ledger, select one available consumer, and dispatch multiple entries to that consumer consecutively. This is dispatcher-side batch dispatch, not producer batching.

The relevant broker path is `PersistentDispatcherMultipleConsumers.trySendMessagesToConsumers`:

https://github.com/apache/pulsar/blob/953bf34a26d647b4640f3087cc27f54f090c878a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L826-L849

`getMaxEntriesInThisBatch` chooses how many entries to send to the selected consumer based on the available permits and `dispatcherMaxRoundRobinBatchSize`. The default `dispatcherMaxRoundRobinBatchSize` is `20`. In this test, each partition only has 3 or 4 messages and each consumer has `receiverQueueSize(7)`, so one consumer can have enough permits to receive all entries for a partition.

Because this is a shared subscription, Pulsar does not guarantee that every consumer receives at least one message.

The test now produces all messages before creating the shared consumers and subscribes the consumers from `SubscriptionInitialPosition.Earliest`. This intentionally lets the messages accumulate in the partition backlog before dispatch starts, which makes the flaky scenario easier to reproduce: when the consumers subscribe, the broker can read multiple pending entries and dispatch them to the first available shared consumer according to its permits.

### Modifications

- Produce messages before creating the consumers and subscribe from `Earliest`, making the original flaky condition easier to reproduce.
- Replace the initial blocking `receive()` calls with timed receive loops.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
