### PR TITLE
[fix][client] Avoid NPE in Consumer.hasMessageAvailable() before calling receive() method

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCreationTest.java
@@ -19,10 +19,13 @@
 
 package org.apache.pulsar.client.api;
 
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 import lombok.Cleanup;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException.NotAllowedException;
+import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.testng.annotations.AfterMethod;
@@ -52,6 +55,62 @@ public class ConsumerCreationTest extends ProducerConsumerBase {
                 {TopicDomain.persistent},
                 {TopicDomain.non_persistent}
         };
+    }
+
+    @Test
+    public void testHasMessageAvailableBeforeReceiveOnSubscribedConsumer() throws Exception {
+        String topic = newTopicName();
+
+        @Cleanup
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Exclusive)
+                .subscribe();
+
+        assertFalse(consumer.hasMessageAvailable());
+    }
+
+    @Test
+    public void testHasMessageAvailableBeforeReceiveWithEarliestInitialPosition() throws Exception {
+        String topic = newTopicName();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .create();
+        producer.send(new byte[] {1});
+
+        @Cleanup
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Exclusive)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe();
+
+        assertTrue(consumer.hasMessageAvailable());
+    }
+
+    @Test
+    public void testHasMessageAvailableBeforeReceiveWithLatestInitialPosition() throws Exception {
+        String topic = newTopicName();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .create();
+        producer.send(new byte[] {1});
+
+        @Cleanup
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Exclusive)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Latest)
+                .subscribe();
+
+        assertFalse(consumer.hasMessageAvailable());
     }
 
     @Test(dataProvider = "topicDomainProvider")

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2725,10 +2725,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             // if we are starting from latest, we should seek to the actual last message first.
             // allow the last one to be read when read head inclusively.
             final boolean hasSoughtByTimestamp = this.hasSoughtByTimestamp;
-            if (MessageId.latest.equals(startMessageId) || hasSoughtByTimestamp) {
+            final boolean startFromLatest = MessageId.latest.equals(startMessageId);
+            if (startFromLatest || hasSoughtByTimestamp || startMessageId == null) {
                 CompletableFuture<GetLastMessageIdResponse> future = internalGetLastMessageIdAsync();
                 // if the consumer is configured to read inclusive then we need to seek to the last message
-                if (resetIncludeHead && !hasSoughtByTimestamp) {
+                if (resetIncludeHead && startFromLatest) {
                     future = future.thenCompose((lastMessageIdResponse) ->
                             seekAsync(lastMessageIdResponse.lastMessageId)
                                     .thenApply((ignore) -> lastMessageIdResponse));


### PR DESCRIPTION
Fixes: https://github.com/apache/pulsar/issues/25837

### Motivation

Calling `Consumer#hasMessageAvailable()` before receiving any messages can hit a `NullPointerException` for a normal consumer because `startMessageId` may be `null`. In that state, `hasMessageAvailable()` should rely on the broker response and compare the mark-delete position instead of passing a null message id into `hasMoreMessages`.

### Modifications

- Treat a null `startMessageId` as a subscription-position based consumer and fetch the latest message id response before deciding availability.
- Keep the inclusive seek behavior limited to consumers that actually start from `MessageId.latest`.
- Add coverage for `hasMessageAvailable()` before receive with default, earliest, and latest initial positions.

### Verifying this change

This change added tests and can be verified as follows:

- `./gradlew :pulsar-client-original:compileJava`
- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.client.api.ConsumerCreationTest`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment