### PR TITLE
[fix][client] Prevent duplicate ServiceUrlProvider initialization

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
@@ -99,7 +99,6 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
                 .tlsTrustCertsFilePath(CA_CERT_FILE_PATH);
         }
         final PulsarClient client = clientBuilder.build();
-        failover.initialize(client);
         final EventLoopGroup executor = WhiteboxImpl.getInternalState(failover, "executor");
         final PulsarServiceState[] stateArray =
                 WhiteboxImpl.getInternalState(failover, "pulsarServiceStateArray");
@@ -139,6 +138,20 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
         producer.close();
         client.close();
         dummyServer.close();
+    }
+
+    @Test
+    public void testInitializeCanOnlyBeCalledOnce() throws Exception {
+        setup();
+        final SameAuthParamsLookupAutoClusterFailover failover = SameAuthParamsLookupAutoClusterFailover.builder()
+                .pulsarServiceUrlArray(new String[]{pulsar1.getBrokerServiceUrl()})
+                .checkHealthyIntervalMs(1000)
+                .build();
+
+        try (PulsarClient client = PulsarClient.builder().serviceUrlProvider(failover).build()) {
+            Throwable error = Assert.expectThrows(IllegalStateException.class, () -> failover.initialize(client));
+            Assert.assertEquals(error.getMessage(), "ServiceUrlProvider has already been initialized");
+        }
     }
 
     /**

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ServiceUrlProvider.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ServiceUrlProvider.java
@@ -27,6 +27,11 @@ import org.apache.pulsar.common.classification.InterfaceStability;
  * <p>This allows applications to retrieve the service URL from an external configuration provider and,
  * more importantly, to force the Pulsar client to reconnect if the service URL has been changed.
  *
+ * <p>Each provider instance is tied to the lifecycle of one {@link PulsarClient} instance. The client
+ * initializes the provider when the client is created and closes the provider when the owning client is
+ * closed. Applications that create multiple Pulsar clients should create a separate provider instance
+ * for each client instead of sharing one provider.
+ *
  * <p>It can be passed with {@link ClientBuilder#serviceUrlProvider(ServiceUrlProvider)}
  */
 @InterfaceAudience.Public
@@ -38,6 +43,9 @@ public interface ServiceUrlProvider extends AutoCloseable {
      *
      * <p>This can be used by the provider to force the Pulsar client to reconnect whenever the service url might have
      * changed. See {@link PulsarClient#updateServiceUrl(String)}.
+     *
+     * <p>This method is invoked by the Pulsar client and is expected to be called once for a provider
+     * instance. Implementations may reject repeated initialization.
      *
      * @param client
      *            created pulsar client.
@@ -52,7 +60,8 @@ public interface ServiceUrlProvider extends AutoCloseable {
     String getServiceUrl();
 
     /**
-     * Close the resource that the provider allocated.
+     * Close the resource that the provider allocated. The owning Pulsar client invokes this method when
+     * it is closed.
      *
      */
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java
@@ -86,7 +86,10 @@ public class AutoClusterFailover implements ServiceUrlProvider {
     }
 
     @Override
-    public void initialize(PulsarClient client) {
+    public synchronized void initialize(PulsarClient client) {
+        if (this.pulsarClient != null) {
+            throw new IllegalStateException("ServiceUrlProvider has already been initialized");
+        }
         this.pulsarClient = (PulsarClientImpl) client;
         this.addressResolver = pulsarClient.getAddressResolver();
         ClientConfigurationData config = pulsarClient.getConfiguration();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java
@@ -40,6 +40,14 @@ import org.apache.pulsar.client.api.ServiceUrlProvider;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.util.ExecutorProvider;
 
+/**
+ * A service URL provider that automatically fails over from the primary Pulsar service URL to one of
+ * the secondary service URLs and switches back after the primary service recovers.
+ *
+ * <p>Each instance is tied to the lifecycle of one {@link PulsarClient}. Once initialized by a
+ * Pulsar client, it must not be reused by another client. Create a new provider instance for each
+ * Pulsar client.
+ */
 @CustomLog
 @Data
 public class AutoClusterFailover implements ServiceUrlProvider {
@@ -126,7 +134,7 @@ public class AutoClusterFailover implements ServiceUrlProvider {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         this.executor.shutdown();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ControlledClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ControlledClusterFailover.java
@@ -111,7 +111,10 @@ public class ControlledClusterFailover implements ServiceUrlProvider {
     }
 
     @Override
-    public void initialize(PulsarClient client) {
+    public synchronized void initialize(PulsarClient client) {
+        if (this.pulsarClient != null) {
+            throw new IllegalStateException("ServiceUrlProvider has already been initialized");
+        }
         this.pulsarClient = (PulsarClientImpl) client;
         this.httpClient = buildHttpClient();
         this.requestBuilder = httpClient.prepareGet(urlProvider)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ControlledClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ControlledClusterFailover.java
@@ -57,6 +57,14 @@ import org.asynchttpclient.Response;
 import org.asynchttpclient.channel.DefaultKeepAliveStrategy;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * A service URL provider that fetches controlled failover configuration from an external HTTP service
+ * and updates the Pulsar client when the returned configuration changes.
+ *
+ * <p>Each instance is tied to the lifecycle of one {@link PulsarClient}. Once initialized by a
+ * Pulsar client, it must not be reused by another client. Create a new provider instance for each
+ * Pulsar client.
+ */
 @CustomLog
 public class ControlledClusterFailover implements ServiceUrlProvider {
     private static final int DEFAULT_CONNECT_TIMEOUT_IN_SECONDS = 10;
@@ -226,7 +234,7 @@ public class ControlledClusterFailover implements ServiceUrlProvider {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         this.executor.shutdown();
         if (httpClient != null) {
             try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
@@ -65,7 +65,10 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
     private SameAuthParamsLookupAutoClusterFailover() {}
 
     @Override
-    public void initialize(PulsarClient client) {
+    public synchronized void initialize(PulsarClient client) {
+        if (this.pulsarClient != null) {
+            throw new IllegalStateException("ServiceUrlProvider has already been initialized");
+        }
         this.currentPulsarServiceIndex = 0;
         this.pulsarClient = (PulsarClientImpl) client;
         this.executor = EventLoopUtil.newEventLoopGroup(1, false,
@@ -377,4 +380,3 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
         }
     }
 }
-

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
@@ -37,6 +37,14 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 
+/**
+ * A service URL provider that probes multiple Pulsar service URLs with the same authentication
+ * parameters and fails over according to service health.
+ *
+ * <p>Each instance is tied to the lifecycle of one {@link PulsarClient}. Once initialized by a
+ * Pulsar client, it must not be reused by another client. Create a new provider instance for each
+ * Pulsar client.
+ */
 @CustomLog
 @SuppressFBWarnings(value = {"EI_EXPOSE_REP2"})
 public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvider {
@@ -113,7 +121,7 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
 
     @SuppressWarnings("deprecation")
     @Override
-    public void close() throws Exception {
+    public synchronized void close() throws Exception {
         if (closed) {
             return;
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -31,10 +31,12 @@ import lombok.Cleanup;
 import lombok.CustomLog;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.ServiceUrlProvider;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-impl")
@@ -145,6 +147,25 @@ public class AutoClusterFailoverTest {
             assertEquals(autoClusterFailover.getFailedTimestamp(), -1);
 
             Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
+        }
+    }
+
+    @Test
+    public void testInitializeCanOnlyBeCalledOnce() throws Exception {
+        String primary = "pulsar://localhost:6650";
+        String secondary = "pulsar://localhost:6651";
+
+        ServiceUrlProvider provider = AutoClusterFailover.builder()
+                .primary(primary)
+                .secondary(Collections.singletonList(secondary))
+                .failoverDelay(1, TimeUnit.SECONDS)
+                .switchBackDelay(1, TimeUnit.SECONDS)
+                .checkInterval(30, TimeUnit.SECONDS)
+                .build();
+
+        try (PulsarClient client = PulsarClient.builder().serviceUrlProvider(provider).build()) {
+            Throwable error = Assert.expectThrows(IllegalStateException.class, () -> provider.initialize(client));
+            assertEquals(error.getMessage(), "ServiceUrlProvider has already been initialized");
         }
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ControlledClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ControlledClusterFailoverTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.ServiceUrlProvider;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.asynchttpclient.Request;
@@ -71,6 +72,22 @@ public class ControlledClusterFailoverTest {
         Assert.assertEquals(urlProvider, request.getUri().toUrl());
         Assert.assertEquals(request.getHeaders().get(keyA), valueA);
         Assert.assertEquals(request.getHeaders().get(keyB), valueB);
+    }
+
+    @Test
+    public void testInitializeCanOnlyBeCalledOnce() throws Exception {
+        String defaultServiceUrl = "pulsar://localhost:6650";
+        String urlProvider = "http://localhost:8080/test";
+
+        ServiceUrlProvider provider = ControlledClusterFailover.builder()
+            .defaultServiceUrl(defaultServiceUrl)
+            .urlProvider(urlProvider)
+            .build();
+
+        try (PulsarClient client = PulsarClient.builder().serviceUrlProvider(provider).build()) {
+            Throwable error = Assert.expectThrows(IllegalStateException.class, () -> provider.initialize(client));
+            Assert.assertEquals(error.getMessage(), "ServiceUrlProvider has already been initialized");
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation

apache/pulsar#25892 fixed a flaky `SameAuthParamsLookupAutoClusterFailoverTest` by removing an extra manual `failover.initialize(client)` call from the test.

The root cause of that flakiness was duplicate initialization. `PulsarClientBuilder.build()` already initializes the configured `ServiceUrlProvider` through `PulsarClientImpl`, so calling `initialize(client)` again starts duplicate background checks for the same provider instance.

This is especially problematic for `SameAuthParamsLookupAutoClusterFailover`, because each `initialize` call creates a new `broker-service-url-check` `EventLoopGroup`. Multiple checker threads can then mutate the same failover state and produce subtle race conditions that are difficult to diagnose. `AutoClusterFailover` and `ControlledClusterFailover` have the same lifecycle risk: duplicate initialization can register duplicate scheduled tasks, and `ControlledClusterFailover` can also recreate its HTTP client without closing the previous one.

### Modifications

- Make AutoClusterFailover, ControlledClusterFailover, and SameAuthParamsLookupAutoClusterFailover fail fast when initialize(PulsarClient) is called more than once.
- Remove the duplicate manual initialize call from SameAuthParamsLookupAutoClusterFailoverTest.testAutoClusterFailover because the provider is already initialized by PulsarClientBuilder.build().
- Add dedicated tests that build a PulsarClient with each provider and then verify a second initialize(client) call throws IllegalStateException.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

The threading model is affected only by preventing duplicate background failover check tasks from being registered for the same ServiceUrlProvider instance.
