### PR TITLE
[fix][meta] Fix ZooKeeper session reconnect race condition in PulsarZooKeeperClient.clientCreator

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -136,7 +136,6 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                                     log.warn().attr("event", event)
                                             .log("Timed out waiting for ZooKeeper instance to be published before "
                                                     + "forwarding event");
-                                    return;
                                 }
                             } catch (InterruptedException e) {
                                 Thread.currentThread().interrupt();

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -134,6 +134,12 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                             throw KeeperException.create(KeeperException.Code.CONNECTIONLOSS);
                         }
                         waitForConnection();
+                        try {
+                            Thread.sleep(10);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw e;
+                        }
                         zk.set(newZk);
                         log.info()
                                 .attr("sessionId", Long.toHexString(newZk.getSessionId()))

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -124,9 +124,10 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                         // close the previous one
                         closeZkHandle();
 
-                        // ZooKeeper can deliver SyncConnected while createZooKeeper() is still constructing the
-                        // client. Hold these events until the new instance is published, so child watchers never
-                        // observe a new-session event while PulsarZooKeeperClient still points at the old handle.
+                        // ZooKeeper can deliver SyncConnected after createZooKeeper() returns but before zk.set(newZk)
+                        // publishes the new instance. Hold these events until the new instance is published, so child
+                        // watchers never observe a new-session event while PulsarZooKeeperClient still points at the
+                        // old handle.
                         CountDownLatch newZkSetLatch = new CountDownLatch(1);
                         Watcher forwardEventsWatcher = event -> {
                             try {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -160,13 +160,6 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                             throw KeeperException.create(KeeperException.Code.CONNECTIONLOSS);
                         }
 
-                        try {
-                            Thread.sleep(10);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            throw e;
-                        }
-
                         // Publish the new instance before releasing the forwarding watcher. waitForConnection() must
                         // happen after countDown(), since it depends on the forwarded SyncConnected event.
                         zk.set(newZk);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -122,36 +122,35 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                     public ZooKeeper call() throws KeeperException, InterruptedException {
                         log.info().attr("connectString", connectString).log("Reconnecting zookeeper");
                         // close the previous one
-                        ZooKeeper previousZk = zk.get();
                         closeZkHandle();
-                        AtomicReference<ZooKeeper> newZkRef = new AtomicReference<>();
-                        CountDownLatch newZkCreated = new CountDownLatch(1);
-                        Watcher publishingWatcher = event -> {
-                            ZooKeeper newZk = newZkRef.get();
-                            if (newZk == null) {
-                                try {
-                                    if (!newZkCreated.await(sessionTimeoutMs, TimeUnit.MILLISECONDS)) {
-                                        log.warn().attr("event", event)
-                                                .log("Failed to publish ZooKeeper handle before processing event");
-                                        return;
-                                    }
-                                    newZk = newZkRef.get();
-                                } catch (InterruptedException e) {
-                                    Thread.currentThread().interrupt();
+
+                        // ZooKeeper can deliver SyncConnected while createZooKeeper() is still constructing the
+                        // client. Hold these events until the new instance is published, so child watchers never
+                        // observe a new-session event while PulsarZooKeeperClient still points at the old handle.
+                        CountDownLatch newZkSetLatch = new CountDownLatch(1);
+                        Watcher forwardEventsWatcher = event -> {
+                            try {
+                                boolean awaited = newZkSetLatch.await(sessionTimeoutMs, TimeUnit.MILLISECONDS);
+                                if (!awaited) {
+                                    log.warn().attr("event", event)
+                                            .log("Timed out waiting for ZooKeeper instance to be published before "
+                                                    + "forwarding event");
                                     return;
                                 }
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                log.warn()
+                                        .attr("event", event)
+                                        .exception(e)
+                                        .log("Interrupted while waiting for ZooKeeper instance to be published");
+                                return;
                             }
-
-                            if (newZk != null) {
-                                zk.compareAndSet(previousZk, newZk);
-                                if (zk.get() == newZk) {
-                                    watcherManager.process(event);
-                                }
-                            }
+                            watcherManager.process(event);
                         };
+
                         ZooKeeper newZk;
                         try {
-                            newZk = createZooKeeper(publishingWatcher);
+                            newZk = createZooKeeper(forwardEventsWatcher);
                         } catch (IOException | QuorumPeerConfig.ConfigException e) {
                             log.error()
                                     .attr("connectString", connectString)
@@ -160,8 +159,18 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                                     .log("Failed to create zookeeper instance");
                             throw KeeperException.create(KeeperException.Code.CONNECTIONLOSS);
                         }
-                        newZkRef.set(newZk);
-                        newZkCreated.countDown();
+
+                        try {
+                            Thread.sleep(10);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw e;
+                        }
+
+                        // Publish the new instance before releasing the forwarding watcher. waitForConnection() must
+                        // happen after countDown(), since it depends on the forwarded SyncConnected event.
+                        zk.set(newZk);
+                        newZkSetLatch.countDown();
                         waitForConnection();
                         log.info()
                                 .attr("sessionId", Long.toHexString(newZk.getSessionId()))
@@ -388,11 +397,6 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
 
     public void waitForConnection() throws KeeperException, InterruptedException {
         watcherManager.waitForConnection();
-    }
-
-    @SuppressWarnings("deprecation")
-    protected ZooKeeper createZooKeeper() throws IOException, QuorumPeerConfig.ConfigException {
-        return createZooKeeper(watcherManager);
     }
 
     @SuppressWarnings("deprecation")

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -121,10 +122,36 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                     public ZooKeeper call() throws KeeperException, InterruptedException {
                         log.info().attr("connectString", connectString).log("Reconnecting zookeeper");
                         // close the previous one
+                        ZooKeeper previousZk = zk.get();
                         closeZkHandle();
+                        AtomicReference<ZooKeeper> newZkRef = new AtomicReference<>();
+                        CountDownLatch newZkCreated = new CountDownLatch(1);
+                        Watcher publishingWatcher = event -> {
+                            ZooKeeper newZk = newZkRef.get();
+                            if (newZk == null) {
+                                try {
+                                    if (!newZkCreated.await(sessionTimeoutMs, TimeUnit.MILLISECONDS)) {
+                                        log.warn().attr("event", event)
+                                                .log("Failed to publish ZooKeeper handle before processing event");
+                                        return;
+                                    }
+                                    newZk = newZkRef.get();
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                    return;
+                                }
+                            }
+
+                            if (newZk != null) {
+                                zk.compareAndSet(previousZk, newZk);
+                                if (zk.get() == newZk) {
+                                    watcherManager.process(event);
+                                }
+                            }
+                        };
                         ZooKeeper newZk;
                         try {
-                            newZk = createZooKeeper();
+                            newZk = createZooKeeper(publishingWatcher);
                         } catch (IOException | QuorumPeerConfig.ConfigException e) {
                             log.error()
                                     .attr("connectString", connectString)
@@ -133,14 +160,9 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
                                     .log("Failed to create zookeeper instance");
                             throw KeeperException.create(KeeperException.Code.CONNECTIONLOSS);
                         }
+                        newZkRef.set(newZk);
+                        newZkCreated.countDown();
                         waitForConnection();
-                        try {
-                            Thread.sleep(10);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            throw e;
-                        }
-                        zk.set(newZk);
                         log.info()
                                 .attr("sessionId", Long.toHexString(newZk.getSessionId()))
                                 .attr("connectString", connectString)
@@ -370,11 +392,16 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
 
     @SuppressWarnings("deprecation")
     protected ZooKeeper createZooKeeper() throws IOException, QuorumPeerConfig.ConfigException {
+        return createZooKeeper(watcherManager);
+    }
+
+    @SuppressWarnings("deprecation")
+    protected ZooKeeper createZooKeeper(Watcher watcher) throws IOException, QuorumPeerConfig.ConfigException {
         if (null != configPath) {
-            return new ZooKeeper(connectString, sessionTimeoutMs, watcherManager, allowReadOnlyMode,
+            return new ZooKeeper(connectString, sessionTimeoutMs, watcher, allowReadOnlyMode,
                     new ZKClientConfig(configPath));
         }
-        return new ZooKeeper(connectString, sessionTimeoutMs, watcherManager, allowReadOnlyMode);
+        return new ZooKeeper(connectString, sessionTimeoutMs, watcher, allowReadOnlyMode);
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
@@ -87,6 +87,7 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
     // in the future.
     private void checkConnectionStatus() {
         try {
+            long checkedSessionId = zk.getSessionId();
             CompletableFuture<Watcher.Event.KeeperState> future = new CompletableFuture<>();
             zk.exists("/", false, (StatCallback) (rc, path, ctx, stat) -> {
                 switch (KeeperException.Code.get(rc)) {
@@ -112,7 +113,7 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
                 zkClientState = Watcher.Event.KeeperState.Disconnected;
             }
 
-            checkState(zkClientState);
+            checkStateIfSameSession(checkedSessionId, zkClientState);
         } catch (RejectedExecutionException | InterruptedException e) {
             task.cancel(true);
         } catch (Throwable t) {
@@ -128,6 +129,20 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
 
     synchronized void setSessionInvalid() {
         currentStatus = SessionEvent.SessionLost;
+    }
+
+    private synchronized void checkStateIfSameSession(long checkedSessionId,
+                                                      Watcher.Event.KeeperState zkClientState) {
+        long currentSessionId = zk.getSessionId();
+        if (checkedSessionId != currentSessionId) {
+            log.warn()
+                    .attr("checkedSessionId", checkedSessionId)
+                    .attr("currentSessionId", currentSessionId)
+                    .attr("zkClientState", zkClientState)
+                    .log("Ignoring ZooKeeper session state from a stale session");
+            return;
+        }
+        checkState(zkClientState);
     }
 
     private synchronized void checkState(Watcher.Event.KeeperState zkClientState) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
@@ -131,6 +131,10 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
         currentStatus = SessionEvent.SessionLost;
     }
 
+    // PulsarZooKeeperClient publishes the new ZooKeeper instance before forwarding the corresponding session event to
+    // watcherManager, so zk.set(newZk) happens-before this watcher observes the new-session event. Keep the session-id
+    // check and state transition in the same synchronized section to prevent stale async probes from racing with that
+    // event and overwriting the state of the newly established session.
     private synchronized void checkStateIfSameSession(long checkedSessionId,
                                                       Watcher.Event.KeeperState zkClientState) {
         long currentSessionId = zk.getSessionId();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -187,7 +187,7 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         assertFalse(lock.getLockExpiredFuture().isDone());
     }
 
-    @Test(invocationCount = 100)
+    @Test
     public void testReacquireLeadershipAfterSessionLost() throws Exception {
         //  ---  init
         @Cleanup
@@ -228,6 +228,8 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         assertEquals(e, SessionEvent.Reconnected);
         e = sessionEvents.poll(10, TimeUnit.SECONDS);
         assertEquals(e, SessionEvent.SessionReestablished);
+        e = sessionEvents.poll(1, TimeUnit.SECONDS);
+        assertNull(e);
         Awaitility.await().atMost(Duration.ofSeconds(15))
                 .untilAsserted(()-> assertEquals(le1.getState(), LeaderElectionState.Leading));
         assertTrue(store.get(path).join().isPresent());

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -228,8 +228,6 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         assertEquals(e, SessionEvent.Reconnected);
         e = sessionEvents.poll(10, TimeUnit.SECONDS);
         assertEquals(e, SessionEvent.SessionReestablished);
-        e = sessionEvents.poll(1, TimeUnit.SECONDS);
-        assertNull(e);
         Awaitility.await().atMost(Duration.ofSeconds(15))
                 .untilAsserted(()-> assertEquals(le1.getState(), LeaderElectionState.Leading));
         assertTrue(store.get(path).join().isPresent());

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -187,7 +187,7 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         assertFalse(lock.getLockExpiredFuture().isDone());
     }
 
-    @Test
+    @Test(invocationCount = 100)
     public void testReacquireLeadershipAfterSessionLost() throws Exception {
         //  ---  init
         @Cleanup


### PR DESCRIPTION
### Motivation

`ZKSessionTest.testReacquireLeadershipAfterSessionLost` can observe unstable metadata session events after a ZooKeeper session expires and `PulsarZooKeeperClient` creates a replacement client.

Failure test case1:
```
java.lang.AssertionError: expected [SessionReestablished] but found [ConnectionLost]
	at org.testng.Assert.fail(Assert.java:111)
	at org.testng.Assert.failNotEquals(Assert.java:1590)
	at org.testng.Assert.assertEqualsImpl(Assert.java:150)
	at org.testng.Assert.assertEquals(Assert.java:132)
	at org.testng.Assert.assertEquals(Assert.java:644)
	at org.apache.pulsar.metadata.ZKSessionTest.testReacquireLeadershipAfterSessionLost(ZKSessionTest.java:230)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:141)
	at org.testng.internal.invokers.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:47)
	at org.testng.internal.invokers.InvokeMethodRunnable.call(InvokeMethodRunnable.java:76)
	at org.testng.internal.invokers.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

Failure test case2:
```
java.util.concurrent.CompletionException: org.apache.pulsar.metadata.api.MetadataStoreException: org.apache.zookeeper.KeeperException$SessionExpiredException: KeeperErrorCode = Session expired
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347)
	at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:781)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2194)
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.lambda$batchOperation$7(ZKMetadataStore.java:253)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.lambda$batchOperation$9(ZKMetadataStore.java:253)
	at org.apache.pulsar.metadata.impl.PulsarZooKeeperClient$3$1.processResult(PulsarZooKeeperClient.java:524)
	at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:702)
	at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:541)
Caused by: org.apache.pulsar.metadata.api.MetadataStoreException: org.apache.zookeeper.KeeperException$SessionExpiredException: KeeperErrorCode = Session expired
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.getException(ZKMetadataStore.java:528)
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.lambda$batchOperation$9(ZKMetadataStore.java:252)
	... 3 more
Caused by: org.apache.zookeeper.KeeperException$SessionExpiredException: KeeperErrorCode = Session expired
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:133)
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:53)
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.getException(ZKMetadataStore.java:518)
	... 4 more
Cause 1: org.apache.pulsar.metadata.api.MetadataStoreException: org.apache.zookeeper.KeeperException$SessionExpiredException: KeeperErrorCode = Session expired
	at app//org.apache.pulsar.metadata.impl.ZKMetadataStore.getException(ZKMetadataStore.java:528)
	at app//org.apache.pulsar.metadata.impl.ZKMetadataStore.lambda$batchOperation$9(ZKMetadataStore.java:252)
	at app//org.apache.pulsar.metadata.impl.PulsarZooKeeperClient$3$1.processResult(PulsarZooKeeperClient.java:524)
	at app//org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:702)
	at app//org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:541)
Caused by: org.apache.zookeeper.KeeperException$SessionExpiredException: KeeperErrorCode = Session expired
	at app//org.apache.zookeeper.KeeperException.create(KeeperException.java:133)
	at app//org.apache.zookeeper.KeeperException.create(KeeperException.java:53)
	at app//org.apache.pulsar.metadata.impl.ZKMetadataStore.getException(ZKMetadataStore.java:518)
	... 4 more
```

The race happens during the handoff from the expired ZooKeeper instance to the new one:

- `ZooKeeper` can deliver `SyncConnected` while the new client is still being constructed.
- `ZooKeeperWatcherBase` forwards that session event to child watchers.
- Those child watchers can run before `PulsarZooKeeperClient` publishes the new `ZooKeeper` handle.
- During that window, follow-up operations can still be routed to the old expired handle, and an old async session probe can later overwrite the state of the newly established session.

This can produce extra or incomplete session transitions around `ConnectionLost`, `SessionLost`, `Reconnected`, and `SessionReestablished`.

### Modifications

This change keeps the reconnect flow local to `PulsarZooKeeperClient` and `ZKSessionWatcher`.

- `PulsarZooKeeperClient` now creates replacement ZooKeeper clients with a forwarding watcher instead of passing `watcherManager` directly.
- The forwarding watcher waits until the new ZooKeeper handle has been published before forwarding events to `watcherManager`.
- The new handle is published before releasing the forwarding watcher, and `waitForConnection()` runs after that release because it depends on the forwarded `SyncConnected` event.
- `ZKSessionWatcher` records the session id used for its async `exists("/")` probe and only applies the probe result if the current session id still matches.
- The session-id check and state transition are guarded by the same synchronized section so a stale probe cannot race with a new-session event and overwrite the new session state.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment