### PR TITLE
[fix][test] Fix flaky SaslAuthenticateTest.testMaxInflightContext() test

### DIFF
--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
@@ -35,6 +35,7 @@ import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_SERVER;
 import static org.apache.pulsar.common.sasl.SaslConstants.SASL_STATE_SERVER_CHECK_TOKEN;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -332,6 +333,16 @@ public class AuthenticationProviderSasl implements AuthenticationProvider {
                 return false;
             }
         }
+    }
+
+    @VisibleForTesting
+    Cache<Long, AuthenticationState> getAuthStates() {
+        return authStates;
+    }
+
+    @VisibleForTesting
+    void setAuthStates(Cache<Long, AuthenticationState> authStates) {
+        this.authStates = authStates;
     }
 
     private String sanitizeHeaderValue(String value) {

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
@@ -364,7 +364,7 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
         @Cleanup
         AuthenticationProviderSasl saslServer = new AuthenticationProviderSasl();
         HttpServletRequest servletRequest = mock(HttpServletRequest.class);
-        doReturn("Init").when(servletRequest).getHeader("State");
+        doReturn(SaslConstants.SASL_STATE_CLIENT_INIT).when(servletRequest).getHeader(SaslConstants.SASL_HEADER_STATE);
         conf.setInflightSaslContextExpiryMs(Integer.MAX_VALUE);
         conf.setMaxInflightSaslContext(1);
         saslServer.initialize(AuthenticationProvider.Context.builder().config(conf).build());
@@ -373,8 +373,8 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
             AuthenticationDataProvider dataProvider =  authSasl.getAuthData("localhost");
             AuthData initData1 = dataProvider.authenticate(AuthData.INIT_AUTH_DATA);
             doReturn(Base64.getEncoder().encodeToString(initData1.getBytes())).when(
-                    servletRequest).getHeader("SASL-Token");
-            doReturn(String.valueOf(i)).when(servletRequest).getHeader("SASL-Server-ID");
+                    servletRequest).getHeader(SaslConstants.SASL_AUTH_TOKEN);
+            doReturn(String.valueOf(i)).when(servletRequest).getHeader(SaslConstants.SASL_STATE_SERVER);
             saslServer.authenticateHttpRequest(servletRequest, mock(HttpServletResponse.class));
         }
         Cache<Long, AuthenticationState> cache = saslServer.getAuthStates();
@@ -389,7 +389,7 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
         @Cleanup
         AuthenticationProviderSasl saslServer = new AuthenticationProviderSasl();
         HttpServletRequest servletRequest = mock(HttpServletRequest.class);
-        doReturn("Init").when(servletRequest).getHeader("State");
+        doReturn(SaslConstants.SASL_STATE_CLIENT_INIT).when(servletRequest).getHeader(SaslConstants.SASL_HEADER_STATE);
         conf.setInflightSaslContextExpiryMs(Integer.MAX_VALUE);
         conf.setMaxInflightSaslContext(1);
         saslServer.initialize(AuthenticationProvider.Context.builder().config(conf).build());
@@ -418,8 +418,8 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
                 AuthenticationDataProvider dataProvider = authSasl.getAuthData("localhost");
                 AuthData initData1 = dataProvider.authenticate(AuthData.INIT_AUTH_DATA);
                 doReturn(Base64.getEncoder().encodeToString(initData1.getBytes())).when(
-                        servletRequest).getHeader("SASL-Token");
-                doReturn(String.valueOf(i)).when(servletRequest).getHeader("SASL-Server-ID");
+                        servletRequest).getHeader(SaslConstants.SASL_AUTH_TOKEN);
+                doReturn(String.valueOf(i)).when(servletRequest).getHeader(SaslConstants.SASL_STATE_SERVER);
                 saslServer.authenticateHttpRequest(servletRequest, mock(HttpServletResponse.class));
             }
             assertTrue(maintenanceStarted.await(5, TimeUnit.SECONDS));

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableSet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -42,6 +43,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.security.auth.login.Configuration;
 import lombok.Cleanup;
@@ -356,7 +360,6 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testMaxInflightContext() throws Exception {
         @Cleanup
         AuthenticationProviderSasl saslServer = new AuthenticationProviderSasl();
@@ -374,10 +377,61 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
             doReturn(String.valueOf(i)).when(servletRequest).getHeader("SASL-Server-ID");
             saslServer.authenticateHttpRequest(servletRequest, mock(HttpServletResponse.class));
         }
-        Field field = AuthenticationProviderSasl.class.getDeclaredField("authStates");
-        field.setAccessible(true);
-        Cache<Long, AuthenticationState> cache = (Cache<Long, AuthenticationState>) field.get(saslServer);
+        Cache<Long, AuthenticationState> cache = saslServer.getAuthStates();
         //only 1 context was left in the memory
-        assertEquals(cache.asMap().size(), 1);
+        // Caffeine may perform size-based eviction asynchronously, so force maintenance before asserting.
+        cache.cleanUp();
+        assertEquals(cache.asMap().size(), conf.getMaxInflightSaslContext());
+    }
+
+    @Test
+    public void testMaxInflightContextWithDelayedCaffeineMaintenance() throws Exception {
+        @Cleanup
+        AuthenticationProviderSasl saslServer = new AuthenticationProviderSasl();
+        HttpServletRequest servletRequest = mock(HttpServletRequest.class);
+        doReturn("Init").when(servletRequest).getHeader("State");
+        conf.setInflightSaslContextExpiryMs(Integer.MAX_VALUE);
+        conf.setMaxInflightSaslContext(1);
+        saslServer.initialize(AuthenticationProvider.Context.builder().config(conf).build());
+
+        CountDownLatch maintenanceStarted = new CountDownLatch(1);
+        CountDownLatch allowMaintenance = new CountDownLatch(1);
+        @Cleanup("shutdownNow")
+        ExecutorService maintenanceExecutor = Executors.newSingleThreadExecutor();
+        Cache<Long, AuthenticationState> delayedMaintenanceCache = Caffeine.newBuilder()
+                .maximumSize(conf.getMaxInflightSaslContext())
+                .expireAfterWrite(conf.getInflightSaslContextExpiryMs(), TimeUnit.MILLISECONDS)
+                .executor(command -> maintenanceExecutor.execute(() -> {
+                    maintenanceStarted.countDown();
+                    try {
+                        allowMaintenance.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    command.run();
+                }))
+                .build();
+        saslServer.setAuthStates(delayedMaintenanceCache);
+
+        try {
+            for (int i = 0; i < 10; i++) {
+                AuthenticationDataProvider dataProvider = authSasl.getAuthData("localhost");
+                AuthData initData1 = dataProvider.authenticate(AuthData.INIT_AUTH_DATA);
+                doReturn(Base64.getEncoder().encodeToString(initData1.getBytes())).when(
+                        servletRequest).getHeader("SASL-Token");
+                doReturn(String.valueOf(i)).when(servletRequest).getHeader("SASL-Server-ID");
+                saslServer.authenticateHttpRequest(servletRequest, mock(HttpServletResponse.class));
+            }
+            assertTrue(maintenanceStarted.await(5, TimeUnit.SECONDS));
+
+            Cache<Long, AuthenticationState> cache = saslServer.getAuthStates();
+            assertTrue(cache.asMap().size() > conf.getMaxInflightSaslContext());
+
+            // Caffeine may perform size-based eviction asynchronously, so force maintenance before asserting.
+            cache.cleanUp();
+            assertEquals(cache.asMap().size(), conf.getMaxInflightSaslContext());
+        } finally {
+            allowMaintenance.countDown();
+        }
     }
 }


### PR DESCRIPTION
Fixes #25941

### Motivation

SaslAuthenticateTest.testMaxInflightContext() is flaky because Caffeine may perform size-based eviction asynchronously. The test asserted the cache size immediately after inserting inflight SASL contexts, so it could observe entries before Caffeine maintenance reduced the cache to the configured maximum.

### Modifications

- Added package-private test accessors for the SASL authentication state cache.
- Forced Caffeine maintenance with cleanUp() before asserting the configured max inflight SASL context size.
- Added a regression test that delays Caffeine maintenance to cover the flaky window before verifying cleanUp() applies the configured maximum.
- Replaced SASL header, state, and token string literals in the affected tests with SaslConstants constants.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment