### PR TITLE
[fix][test] Stabilize flaky sweepTimeouts_abortsExpiredOpenTxnAndFansOut() test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/v5/TransactionCoordinatorV5Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/v5/TransactionCoordinatorV5Test.java
@@ -272,9 +272,13 @@ public class TransactionCoordinatorV5Test {
 
     @Test
     public void sweepTimeouts_abortsExpiredOpenTxnAndFansOut() throws Exception {
-        // 1ms timeout → deadline already in the past when the sweep runs.
+        // Wait until the positive timeout has actually expired before running the sweep.
         TxnID txnId = tc.newTransaction(TC_ID, 1L, "owner").get();
         String txnIdKey = TxnIds.toKey(txnId);
+        TxnHeader openHeader = txnStore.getHeader(txnIdKey).get().orElseThrow().value();
+        long deadlineMs = openHeader.getCreatedAt().toEpochMilli() + openHeader.getTimeout().toMillis();
+        Awaitility.await().until(() -> System.currentTimeMillis() >= deadlineMs);
+
         String segment = "segment://public/default/topic/0000-ffff-0";
         txnStore.appendOp(txnIdKey,
                 new TxnOp(TxnOpKind.WRITE, segment, null, 5L, 1L, null)).get();


### PR DESCRIPTION
Fixes apache/pulsar#25940

### Motivation

`TransactionCoordinatorV5Test.sweepTimeouts_abortsExpiredOpenTxnAndFansOut` intended to verify that the timeout sweeper aborts an expired open transaction and fans out the abort decision to the transaction participant.

The test used a 1ms timeout and immediately ran the sweep, assuming the deadline was already in the past. When transaction creation and the sweep happened within the same millisecond, the deadline scan could correctly leave the transaction `OPEN`, making the test flaky.

### Modifications

Wait for the transaction header's actual positive timeout deadline to pass before invoking `sweepTimeouts()`.

This keeps the test exercising the same timeout-sweeper path while removing the millisecond-boundary race.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
